### PR TITLE
Refactor annotation logic: geometry service, number tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs
 
+*.md
+
 # Mono auto generated files
 mono_crash.*
 
@@ -364,3 +366,4 @@ FodyWeavers.xsd
 # Squad
 .squad/
 .squad-templates/
+

--- a/SnippingTool.Tests/Services/AnnotationGeometryServiceTests.cs
+++ b/SnippingTool.Tests/Services/AnnotationGeometryServiceTests.cs
@@ -8,8 +8,6 @@ public class AnnotationGeometryServiceTests
 {
     private readonly AnnotationGeometryService _sut = new();
 
-    // ── CalculateRect ──────────────────────────────────────────────────────
-
     [Fact]
     public void CalculateRect_TopLeftToBottomRight_ReturnsCorrectBounds()
     {
@@ -30,8 +28,6 @@ public class AnnotationGeometryServiceTests
         Assert.Equal(50, height);
     }
 
-    // ── CalculateEllipse ───────────────────────────────────────────────────
-
     [Fact]
     public void CalculateEllipse_SameLogicAsRect()
     {
@@ -39,8 +35,6 @@ public class AnnotationGeometryServiceTests
         var ellipse = _sut.CalculateEllipse(new Point(5, 5), new Point(55, 55));
         Assert.Equal(rect, ellipse);
     }
-
-    // ── IsValidShapeSize ───────────────────────────────────────────────────
 
     [Fact]
     public void IsValidShapeSize_LargeEnough_ReturnsTrue()
@@ -73,8 +67,6 @@ public class AnnotationGeometryServiceTests
         Assert.False(_sut.IsValidShapeSize(new Point(0, 0), new Point(5, 5), minSide: 10));
         Assert.True(_sut.IsValidShapeSize(new Point(0, 0), new Point(10, 10), minSide: 10));
     }
-
-    // ── CalculateArrowHead ─────────────────────────────────────────────────
 
     [Fact]
     public void CalculateArrowHead_ReturnsThreePoints()

--- a/SnippingTool.Tests/Services/AnnotationGeometryServiceTests.cs
+++ b/SnippingTool.Tests/Services/AnnotationGeometryServiceTests.cs
@@ -1,0 +1,117 @@
+using System.Windows;
+using SnippingTool.Services;
+using Xunit;
+
+namespace SnippingTool.Tests.Services;
+
+public class AnnotationGeometryServiceTests
+{
+    private readonly AnnotationGeometryService _sut = new();
+
+    // ── CalculateRect ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateRect_TopLeftToBottomRight_ReturnsCorrectBounds()
+    {
+        var (left, top, width, height) = _sut.CalculateRect(new Point(10, 20), new Point(110, 70));
+        Assert.Equal(10, left);
+        Assert.Equal(20, top);
+        Assert.Equal(100, width);
+        Assert.Equal(50, height);
+    }
+
+    [Fact]
+    public void CalculateRect_BottomRightToTopLeft_NormalizesCorrectly()
+    {
+        var (left, top, width, height) = _sut.CalculateRect(new Point(110, 70), new Point(10, 20));
+        Assert.Equal(10, left);
+        Assert.Equal(20, top);
+        Assert.Equal(100, width);
+        Assert.Equal(50, height);
+    }
+
+    // ── CalculateEllipse ───────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateEllipse_SameLogicAsRect()
+    {
+        var rect = _sut.CalculateRect(new Point(5, 5), new Point(55, 55));
+        var ellipse = _sut.CalculateEllipse(new Point(5, 5), new Point(55, 55));
+        Assert.Equal(rect, ellipse);
+    }
+
+    // ── IsValidShapeSize ───────────────────────────────────────────────────
+
+    [Fact]
+    public void IsValidShapeSize_LargeEnough_ReturnsTrue()
+    {
+        Assert.True(_sut.IsValidShapeSize(new Point(0, 0), new Point(10, 10)));
+    }
+
+    [Fact]
+    public void IsValidShapeSize_TooSmall_ReturnsFalse()
+    {
+        Assert.False(_sut.IsValidShapeSize(new Point(0, 0), new Point(2, 2)));
+    }
+
+    [Fact]
+    public void IsValidShapeSize_ExactlyMinSide_ReturnsTrue()
+    {
+        Assert.True(_sut.IsValidShapeSize(new Point(0, 0), new Point(4, 4)));
+    }
+
+    [Fact]
+    public void IsValidShapeSize_HorizontalLine_ValidByWidth()
+    {
+        // Height=0 but width=100 — valid for line/arrow shapes
+        Assert.True(_sut.IsValidShapeSize(new Point(0, 0), new Point(100, 0)));
+    }
+
+    [Fact]
+    public void IsValidShapeSize_CustomMinSide_RespectsThreshold()
+    {
+        Assert.False(_sut.IsValidShapeSize(new Point(0, 0), new Point(5, 5), minSide: 10));
+        Assert.True(_sut.IsValidShapeSize(new Point(0, 0), new Point(10, 10), minSide: 10));
+    }
+
+    // ── CalculateArrowHead ─────────────────────────────────────────────────
+
+    [Fact]
+    public void CalculateArrowHead_ReturnsThreePoints()
+    {
+        var pts = _sut.CalculateArrowHead(new Point(0, 0), new Point(100, 0));
+        Assert.Equal(3, pts.Length);
+    }
+
+    [Fact]
+    public void CalculateArrowHead_MiddlePointIsArrowTip()
+    {
+        var tip = new Point(100, 0);
+        var pts = _sut.CalculateArrowHead(new Point(0, 0), tip);
+        Assert.Equal(tip, pts[1]);
+    }
+
+    [Fact]
+    public void CalculateArrowHead_HeadPointsAreNearTip()
+    {
+        var tip = new Point(100, 0);
+        var pts = _sut.CalculateArrowHead(new Point(0, 0), tip);
+
+        // Both wing points must be within headLength distance of the tip
+        const double maxDist = 15.0;
+        Assert.True(Distance(pts[0], tip) <= maxDist);
+        Assert.True(Distance(pts[2], tip) <= maxDist);
+    }
+
+    [Fact]
+    public void CalculateArrowHead_Symmetric_AroundShaftAxis()
+    {
+        // Horizontal arrow → both wings should be equidistant from the shaft line (Y axis symmetry)
+        var pts = _sut.CalculateArrowHead(new Point(0, 0), new Point(100, 0));
+        Assert.Equal(pts[0].X, pts[2].X, precision: 8);
+        Assert.Equal(-pts[0].Y, pts[2].Y, precision: 8); // symmetric above/below
+    }
+
+    private static double Distance(Point a, Point b)
+        => Math.Sqrt(Math.Pow(a.X - b.X, 2) + Math.Pow(a.Y - b.Y, 2));
+}

--- a/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
@@ -86,8 +86,6 @@ public class AnnotationViewModelTests
         Assert.True(raised);
     }
 
-    // ── Drawing state machine ──────────────────────────────────────────────
-
     [Fact]
     public void BeginDrawing_SetsIsDragging()
     {
@@ -130,8 +128,6 @@ public class AnnotationViewModelTests
 
         Assert.Equal(new System.Windows.Point(50, 80), vm.DragCurrent);
     }
-
-    // ── TryGetShapeParameters ──────────────────────────────────────────────
 
     [Fact]
     public void TryGetShapeParameters_TooSmall_ReturnsNull()
@@ -218,8 +214,6 @@ public class AnnotationViewModelTests
         Assert.Null(vm.TryGetShapeParameters());
     }
 
-    // ── NumberCounter ──────────────────────────────────────────────────────
-
     [Fact]
     public void IncrementNumberCounter_IncrementsEachCall()
     {
@@ -243,8 +237,6 @@ public class AnnotationViewModelTests
 
         Assert.Equal(0, vm.NumberCounter);
     }
-
-    // ── SetColorFromTag ────────────────────────────────────────────────────
 
     [Theory]
     [InlineData("Red")]
@@ -284,8 +276,6 @@ public class AnnotationViewModelTests
 
         Assert.Equal(Colors.Red, vm.ActiveColor);
     }
-
-    // ── SetStrokeThicknessFromText ─────────────────────────────────────────
 
     [Fact]
     public void SetStrokeThicknessFromText_ValidNumber_SetsThickness()

--- a/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
@@ -218,6 +218,96 @@ public class AnnotationViewModelTests
         Assert.Null(vm.TryGetShapeParameters());
     }
 
+    // ── NumberCounter ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void IncrementNumberCounter_IncrementsEachCall()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+
+        var first = vm.IncrementNumberCounter();
+        var second = vm.IncrementNumberCounter();
+
+        Assert.Equal(1, first);
+        Assert.Equal(2, second);
+    }
+
+    [Fact]
+    public void ResetNumberCounter_SetsValue()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.IncrementNumberCounter();
+        vm.IncrementNumberCounter();
+
+        vm.ResetNumberCounter(0);
+
+        Assert.Equal(0, vm.NumberCounter);
+    }
+
+    // ── SetColorFromTag ────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("Red")]
+    [InlineData("Blue")]
+    [InlineData("Black")]
+    [InlineData("Green")]
+    [InlineData("Orange")]
+    [InlineData("Purple")]
+    [InlineData("White")]
+    [InlineData("Pink")]
+    public void SetColorFromTag_KnownTag_ChangesActiveColor(string tag)
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.ActiveColor = Colors.Transparent;
+
+        vm.SetColorFromTag(tag);
+
+        Assert.NotEqual(Colors.Transparent, vm.ActiveColor);
+    }
+
+    [Fact]
+    public void SetColorFromTag_UnknownTag_FallsBackToRed()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+
+        vm.SetColorFromTag("NotAColor");
+
+        Assert.Equal(Colors.Red, vm.ActiveColor);
+    }
+
+    [Fact]
+    public void SetColorFromTag_Null_FallsBackToRed()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+
+        vm.SetColorFromTag(null);
+
+        Assert.Equal(Colors.Red, vm.ActiveColor);
+    }
+
+    // ── SetStrokeThicknessFromText ─────────────────────────────────────────
+
+    [Fact]
+    public void SetStrokeThicknessFromText_ValidNumber_SetsThickness()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+
+        vm.SetStrokeThicknessFromText("4");
+
+        Assert.Equal(4.0, vm.StrokeThickness);
+    }
+
+    [Fact]
+    public void SetStrokeThicknessFromText_InvalidText_NoOp()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        var original = vm.StrokeThickness;
+
+        vm.SetStrokeThicknessFromText("px");
+
+        Assert.Equal(original, vm.StrokeThickness);
+    }
+
     // Concrete subclass so we can instantiate the abstract-like partial base
     private sealed partial class TestAnnotationViewModel(AnnotationGeometryService geom) : AnnotationViewModel(geom) { }
 }

--- a/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
@@ -184,6 +184,40 @@ public class AnnotationViewModelTests
         Assert.IsType<SnippingTool.Models.EllipseShapeParameters>(result);
     }
 
+    // Every drag-producing tool must return a non-null ShapeParameters.
+    // If a new tool is added to the enum but forgotten in TryGetShapeParameters,
+    // this test will fail and catch the omission.
+    [Theory]
+    [InlineData(AnnotationTool.Arrow)]
+    [InlineData(AnnotationTool.Rectangle)]
+    [InlineData(AnnotationTool.Highlight)]
+    [InlineData(AnnotationTool.Pen)]
+    [InlineData(AnnotationTool.Line)]
+    [InlineData(AnnotationTool.Circle)]
+    public void TryGetShapeParameters_AllDragTools_ReturnNonNull(AnnotationTool tool)
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = tool;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(100, 100));
+
+        Assert.NotNull(vm.TryGetShapeParameters());
+    }
+
+    // Click-only tools must NOT attempt to produce drag geometry.
+    [Theory]
+    [InlineData(AnnotationTool.Text)]
+    [InlineData(AnnotationTool.Number)]
+    public void TryGetShapeParameters_ClickOnlyTools_ReturnNull(AnnotationTool tool)
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = tool;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(100, 100));
+
+        Assert.Null(vm.TryGetShapeParameters());
+    }
+
     // Concrete subclass so we can instantiate the abstract-like partial base
     private sealed partial class TestAnnotationViewModel(AnnotationGeometryService geom) : AnnotationViewModel(geom) { }
 }

--- a/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Windows.Media;
+using SnippingTool.Services;
 using SnippingTool.ViewModels;
 using Xunit;
 
@@ -6,31 +7,33 @@ namespace SnippingTool.Tests.ViewModels;
 
 public class AnnotationViewModelTests
 {
+    private static AnnotationGeometryService Geom() => new();
+
     [Fact]
-    public void DefaultTool_IsArrow()
+    public void DefaultTool_IsRectangle()
     {
-        var vm = new TestAnnotationViewModel();
-        Assert.Equal(AnnotationTool.Arrow, vm.SelectedTool);
+        var vm = new TestAnnotationViewModel(Geom());
+        Assert.Equal(AnnotationTool.Rectangle, vm.SelectedTool);
     }
 
     [Fact]
     public void DefaultColor_IsRed()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         Assert.Equal(Colors.Red, vm.ActiveColor);
     }
 
     [Fact]
     public void DefaultStrokeThickness_Is2Point5()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         Assert.Equal(2.5, vm.StrokeThickness);
     }
 
     [Fact]
     public void ActiveBrush_MatchesActiveColor()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         vm.ActiveColor = Colors.Blue;
         Assert.Equal(Colors.Blue, vm.ActiveBrush.Color);
     }
@@ -38,7 +41,7 @@ public class AnnotationViewModelTests
     [Fact]
     public void ActiveBrush_PropertyChanged_FiredWhenColorChanges()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         var raised = new List<string?>();
         vm.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
 
@@ -50,7 +53,7 @@ public class AnnotationViewModelTests
     [Fact]
     public void SelectedTool_PropertyChanged_Fired()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         var raised = false;
         vm.PropertyChanged += (_, e) =>
         {
@@ -68,7 +71,7 @@ public class AnnotationViewModelTests
     [Fact]
     public void StrokeThickness_PropertyChanged_Fired()
     {
-        var vm = new TestAnnotationViewModel();
+        var vm = new TestAnnotationViewModel(Geom());
         var raised = false;
         vm.PropertyChanged += (_, e) =>
         {
@@ -83,6 +86,104 @@ public class AnnotationViewModelTests
         Assert.True(raised);
     }
 
+    // ── Drawing state machine ──────────────────────────────────────────────
+
+    [Fact]
+    public void BeginDrawing_SetsIsDragging()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+
+        vm.BeginDrawing(new System.Windows.Point(10, 20));
+
+        Assert.True(vm.IsDragging);
+    }
+
+    [Fact]
+    public void CommitDrawing_ClearsIsDragging()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.BeginDrawing(new System.Windows.Point(10, 20));
+
+        vm.CommitDrawing();
+
+        Assert.False(vm.IsDragging);
+    }
+
+    [Fact]
+    public void CancelDrawing_ClearsIsDragging()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.BeginDrawing(new System.Windows.Point(10, 20));
+
+        vm.CancelDrawing();
+
+        Assert.False(vm.IsDragging);
+    }
+
+    [Fact]
+    public void UpdateDrawing_UpdatesDragCurrent()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+
+        vm.UpdateDrawing(new System.Windows.Point(50, 80));
+
+        Assert.Equal(new System.Windows.Point(50, 80), vm.DragCurrent);
+    }
+
+    // ── TryGetShapeParameters ──────────────────────────────────────────────
+
+    [Fact]
+    public void TryGetShapeParameters_TooSmall_ReturnsNull()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Rectangle;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(1, 1)); // too small
+
+        Assert.Null(vm.TryGetShapeParameters());
+    }
+
+    [Fact]
+    public void TryGetShapeParameters_Rectangle_ReturnsRectParams()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Rectangle;
+        vm.BeginDrawing(new System.Windows.Point(10, 10));
+        vm.UpdateDrawing(new System.Windows.Point(60, 60));
+
+        var result = vm.TryGetShapeParameters();
+
+        Assert.IsType<SnippingTool.Models.RectShapeParameters>(result);
+    }
+
+    [Fact]
+    public void TryGetShapeParameters_Arrow_ReturnsArrowParamsWithHead()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Arrow;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(100, 0));
+
+        var result = vm.TryGetShapeParameters() as SnippingTool.Models.ArrowShapeParameters;
+
+        Assert.NotNull(result);
+        Assert.Equal(3, result.ArrowHead.Length);
+    }
+
+    [Fact]
+    public void TryGetShapeParameters_Circle_ReturnsEllipseParams()
+    {
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Circle;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(50, 50));
+
+        var result = vm.TryGetShapeParameters();
+
+        Assert.IsType<SnippingTool.Models.EllipseShapeParameters>(result);
+    }
+
     // Concrete subclass so we can instantiate the abstract-like partial base
-    private sealed partial class TestAnnotationViewModel : AnnotationViewModel { }
+    private sealed partial class TestAnnotationViewModel(AnnotationGeometryService geom) : AnnotationViewModel(geom) { }
 }

--- a/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Windows;
+using SnippingTool.Services;
 using SnippingTool.ViewModels;
 using Xunit;
 
@@ -6,24 +7,26 @@ namespace SnippingTool.Tests.ViewModels;
 
 public class OverlayViewModelTests
 {
+    private static OverlayViewModel Vm() => new(new AnnotationGeometryService());
+
     [Fact]
     public void InitialPhase_IsSelecting()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         Assert.Equal(OverlayViewModel.Phase.Selecting, vm.CurrentPhase);
     }
 
     [Fact]
     public void InitialSelectionRect_IsEmpty()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         Assert.Equal(Rect.Empty, vm.SelectionRect);
     }
 
     [Fact]
     public void CommitSelection_SetsSelectionRect()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         var rect = new Rect(10, 20, 300, 200);
 
         vm.CommitSelection(rect);
@@ -34,7 +37,7 @@ public class OverlayViewModelTests
     [Fact]
     public void CommitSelection_TransitionsToAnnotating()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
 
         vm.CommitSelection(new Rect(0, 0, 100, 100));
 
@@ -44,7 +47,9 @@ public class OverlayViewModelTests
     [Fact]
     public void UpdateSizeLabel_FormatsWithDpi()
     {
-        var vm = new OverlayViewModel { DpiX = 2.0, DpiY = 2.0 };
+        var vm = Vm();
+        vm.DpiX = 2.0;
+        vm.DpiY = 2.0;
 
         vm.UpdateSizeLabel(100, 50);
 
@@ -54,7 +59,7 @@ public class OverlayViewModelTests
     [Fact]
     public void UpdateSizeLabel_DefaultDpi_FormatsCorrectly()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
 
         vm.UpdateSizeLabel(640, 480);
 
@@ -64,7 +69,7 @@ public class OverlayViewModelTests
     [Fact]
     public void CopyCommand_FiresCopyRequested()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         var fired = false;
         vm.CopyRequested += () => fired = true;
 
@@ -76,7 +81,7 @@ public class OverlayViewModelTests
     [Fact]
     public void CloseCommand_FiresCloseRequested()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         var fired = false;
         vm.CloseRequested += () => fired = true;
 
@@ -88,7 +93,7 @@ public class OverlayViewModelTests
     [Fact]
     public void CurrentPhase_PropertyChanged_FiredOnCommit()
     {
-        var vm = new OverlayViewModel();
+        var vm = Vm();
         var raised = false;
         vm.PropertyChanged += (_, e) =>
         {

--- a/SnippingTool.Tests/ViewModels/PreviewViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/PreviewViewModelTests.cs
@@ -130,10 +130,14 @@ public class PreviewViewModelTests
     {
         var vm = Vm();
 
-        vm.BeginGroup(); vm.TrackElement(new object()); vm.CommitGroup();
+        vm.BeginGroup();
+        vm.TrackElement(new object());
+        vm.CommitGroup();
         Assert.Equal(1, vm.UndoCount);
 
-        vm.BeginGroup(); vm.TrackElement(new object()); vm.CommitGroup();
+        vm.BeginGroup();
+        vm.TrackElement(new object());
+        vm.CommitGroup();
         Assert.Equal(2, vm.UndoCount);
 
         vm.UndoCommand.Execute(null);

--- a/SnippingTool.Tests/ViewModels/PreviewViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/PreviewViewModelTests.cs
@@ -1,3 +1,4 @@
+using SnippingTool.Services;
 using SnippingTool.ViewModels;
 using Xunit;
 
@@ -5,24 +6,26 @@ namespace SnippingTool.Tests.ViewModels;
 
 public class PreviewViewModelTests
 {
+    private static PreviewViewModel Vm() => new(new AnnotationGeometryService());
+
     [Fact]
     public void UndoCommand_CannotExecute_WhenStackEmpty()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         Assert.False(vm.UndoCommand.CanExecute(null));
     }
 
     [Fact]
     public void RedoCommand_CannotExecute_WhenStackEmpty()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         Assert.False(vm.RedoCommand.CanExecute(null));
     }
 
     [Fact]
     public void CommitGroup_WithElements_EnablesUndo()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         vm.BeginGroup();
         vm.TrackElement(new object());
         vm.CommitGroup();
@@ -33,7 +36,7 @@ public class PreviewViewModelTests
     [Fact]
     public void CommitGroup_Empty_DoesNotEnableUndo()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         vm.BeginGroup();
         vm.CommitGroup();
 
@@ -43,7 +46,7 @@ public class PreviewViewModelTests
     [Fact]
     public void Undo_MovesGroupToRedoStack()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var element = new object();
         vm.BeginGroup();
         vm.TrackElement(element);
@@ -58,7 +61,7 @@ public class PreviewViewModelTests
     [Fact]
     public void Undo_FiresUndoApplied_WithCorrectGroup()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var element = new object();
         vm.BeginGroup();
         vm.TrackElement(element);
@@ -75,7 +78,7 @@ public class PreviewViewModelTests
     [Fact]
     public void Redo_MovesGroupBackToUndoStack()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         vm.BeginGroup();
         vm.TrackElement(new object());
         vm.CommitGroup();
@@ -90,7 +93,7 @@ public class PreviewViewModelTests
     [Fact]
     public void Redo_FiresRedoApplied_WithCorrectGroup()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var element = new object();
         vm.BeginGroup();
         vm.TrackElement(element);
@@ -108,7 +111,7 @@ public class PreviewViewModelTests
     [Fact]
     public void CommitGroup_ClearsRedoStack()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         vm.BeginGroup();
         vm.TrackElement(new object());
         vm.CommitGroup();
@@ -125,7 +128,7 @@ public class PreviewViewModelTests
     [Fact]
     public void UndoCount_TracksStackDepth()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
 
         vm.BeginGroup(); vm.TrackElement(new object()); vm.CommitGroup();
         Assert.Equal(1, vm.UndoCount);
@@ -140,7 +143,7 @@ public class PreviewViewModelTests
     [Fact]
     public void CopyCommand_FiresCopyRequested()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var fired = false;
         vm.CopyRequested += () => fired = true;
 
@@ -152,7 +155,7 @@ public class PreviewViewModelTests
     [Fact]
     public void SaveCommand_FiresSaveRequested()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var fired = false;
         vm.SaveRequested += () => fired = true;
 
@@ -164,7 +167,7 @@ public class PreviewViewModelTests
     [Fact]
     public void CloseCommand_FiresCloseRequested()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         var fired = false;
         vm.CloseRequested += () => fired = true;
 
@@ -176,7 +179,7 @@ public class PreviewViewModelTests
     [Fact]
     public void TrackElement_BeforeBeginGroup_IsIgnored()
     {
-        var vm = new PreviewViewModel();
+        var vm = Vm();
         vm.TrackElement(new object()); // no active group — should not throw
 
         vm.BeginGroup();

--- a/SnippingTool/AnnotationTool.cs
+++ b/SnippingTool/AnnotationTool.cs
@@ -1,0 +1,3 @@
+namespace SnippingTool;
+
+public enum AnnotationTool { Arrow, Rectangle, Text, Highlight, Pen, Line, Circle, Number }

--- a/SnippingTool/App.xaml.cs
+++ b/SnippingTool/App.xaml.cs
@@ -59,6 +59,7 @@ public partial class App : Application
             UnregisterHotKey(_hotkeySource.Handle, HotkeyId);
             _hotkeySource.Dispose();
         }
+
         _trayIcon?.Dispose();
         _services.Dispose();
         base.OnExit(e);
@@ -85,6 +86,7 @@ public partial class App : Application
             StartSnip();
             handled = true;
         }
+
         return IntPtr.Zero;
     }
 

--- a/SnippingTool/App.xaml.cs
+++ b/SnippingTool/App.xaml.cs
@@ -44,6 +44,7 @@ public partial class App : Application
     private static void ConfigureServices(IServiceCollection services)
     {
         services.AddTransient<IScreenCaptureService, ScreenCaptureService>();
+        services.AddSingleton<IAnnotationGeometryService, AnnotationGeometryService>();
         services.AddTransient<OverlayViewModel>();
         services.AddTransient<PreviewViewModel>();
         services.AddTransient<OverlayWindow>();

--- a/SnippingTool/App.xaml.cs
+++ b/SnippingTool/App.xaml.cs
@@ -1,6 +1,5 @@
 using System.Runtime.InteropServices;
 using System.Windows;
-using System.Windows.Controls;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
 using Hardcodet.Wpf.TaskbarNotification;

--- a/SnippingTool/MainWindow.xaml.cs
+++ b/SnippingTool/MainWindow.xaml.cs
@@ -1,13 +1,4 @@
-using System.Text;
 using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Data;
-using System.Windows.Documents;
-using System.Windows.Input;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using System.Windows.Navigation;
-using System.Windows.Shapes;
 
 namespace SnippingTool;
 

--- a/SnippingTool/Models/ShapeParameters.cs
+++ b/SnippingTool/Models/ShapeParameters.cs
@@ -5,14 +5,14 @@ namespace SnippingTool.Models;
 
 public abstract record ShapeParameters;
 
-public record ArrowShapeParameters(
+public sealed record ArrowShapeParameters(
     Point P1,
     Point P2,
     Color Color,
     double Thickness,
     Point[] ArrowHead) : ShapeParameters;
 
-public record RectShapeParameters(
+public sealed record RectShapeParameters(
     double Left,
     double Top,
     double Width,
@@ -21,7 +21,7 @@ public record RectShapeParameters(
     double Thickness,
     bool IsHighlight) : ShapeParameters;
 
-public record EllipseShapeParameters(
+public sealed record EllipseShapeParameters(
     double Left,
     double Top,
     double Width,
@@ -29,13 +29,13 @@ public record EllipseShapeParameters(
     Color Color,
     double Thickness) : ShapeParameters;
 
-public record LineShapeParameters(
+public sealed record LineShapeParameters(
     Point P1,
     Point P2,
     Color Color,
     double Thickness) : ShapeParameters;
 
-public record PenShapeParameters(
+public sealed record PenShapeParameters(
     Point StartPoint,
     Color Color,
     double Thickness) : ShapeParameters;

--- a/SnippingTool/Models/ShapeParameters.cs
+++ b/SnippingTool/Models/ShapeParameters.cs
@@ -1,0 +1,41 @@
+using Color = System.Windows.Media.Color;
+using Point = System.Windows.Point;
+
+namespace SnippingTool.Models;
+
+public abstract record ShapeParameters;
+
+public record ArrowShapeParameters(
+    Point P1,
+    Point P2,
+    Color Color,
+    double Thickness,
+    Point[] ArrowHead) : ShapeParameters;
+
+public record RectShapeParameters(
+    double Left,
+    double Top,
+    double Width,
+    double Height,
+    Color Color,
+    double Thickness,
+    bool IsHighlight) : ShapeParameters;
+
+public record EllipseShapeParameters(
+    double Left,
+    double Top,
+    double Width,
+    double Height,
+    Color Color,
+    double Thickness) : ShapeParameters;
+
+public record LineShapeParameters(
+    Point P1,
+    Point P2,
+    Color Color,
+    double Thickness) : ShapeParameters;
+
+public record PenShapeParameters(
+    Point StartPoint,
+    Color Color,
+    double Thickness) : ShapeParameters;

--- a/SnippingTool/OverlayWindow.xaml
+++ b/SnippingTool/OverlayWindow.xaml
@@ -154,6 +154,17 @@
           <TextBlock Text="⬭" FontSize="14"/>
         </RadioButton>
 
+        <RadioButton Style="{StaticResource ToolBtn}"
+                     GroupName="AnnotTool"
+                     Tag="Number" Click="Tool_Click" ToolTip="Place numbered label">
+          <Border Width="18" Height="18" BorderBrush="#555" BorderThickness="1.5"
+                  CornerRadius="9" Background="Transparent">
+            <TextBlock Text="1" FontSize="9" FontWeight="Bold"
+                       HorizontalAlignment="Center" VerticalAlignment="Center"
+                       Foreground="#555"/>
+          </Border>
+        </RadioButton>
+
         <!-- Divider -->
         <Rectangle Height="1" Fill="#D0D0D0" Margin="4,5"/>
 

--- a/SnippingTool/OverlayWindow.xaml
+++ b/SnippingTool/OverlayWindow.xaml
@@ -125,8 +125,26 @@
 
         <RadioButton Style="{StaticResource ToolBtn}"
                      GroupName="AnnotTool"
-                     Tag="Text" Click="Tool_Click" ToolTip="Text">
-          <TextBlock Text="T" FontSize="15" FontWeight="Bold"/>
+                     Tag="Line" Click="Tool_Click" ToolTip="Line">
+          <TextBlock Text="╱" FontSize="14"/>
+        </RadioButton>
+
+        <RadioButton Style="{StaticResource ToolBtn}"
+                     GroupName="AnnotTool"
+                     Tag="Rectangle" Click="Tool_Click" ToolTip="Rectangle">
+          <Border Width="16" Height="12" BorderBrush="#555" BorderThickness="1.5" Background="Transparent"/>
+        </RadioButton>
+
+        <RadioButton Style="{StaticResource ToolBtn}"
+                     GroupName="AnnotTool"
+                     Tag="Circle" Click="Tool_Click" ToolTip="Circle">
+          <TextBlock Text="⬭" FontSize="14"/>
+        </RadioButton>
+
+        <RadioButton Style="{StaticResource ToolBtn}"
+                     GroupName="AnnotTool"
+                     Tag="Pen" Click="Tool_Click" ToolTip="Pen">
+          <TextBlock Text="✏" FontSize="14"/>
         </RadioButton>
 
         <RadioButton Style="{StaticResource ToolBtn}"
@@ -138,31 +156,14 @@
 
         <RadioButton Style="{StaticResource ToolBtn}"
                      GroupName="AnnotTool"
-                     Tag="Pen" Click="Tool_Click" ToolTip="Pen">
-          <TextBlock Text="✏" FontSize="14"/>
-        </RadioButton>
-
-        <RadioButton Style="{StaticResource ToolBtn}"
-                     GroupName="AnnotTool"
-                     Tag="Line" Click="Tool_Click" ToolTip="Line">
-          <TextBlock Text="╱" FontSize="14"/>
-        </RadioButton>
-
-        <RadioButton Style="{StaticResource ToolBtn}"
-                     GroupName="AnnotTool"
-                     Tag="Circle" Click="Tool_Click" ToolTip="Circle">
-          <TextBlock Text="⬭" FontSize="14"/>
+                     Tag="Text" Click="Tool_Click" ToolTip="Text">
+          <TextBlock Text="T" FontSize="15" FontWeight="Bold"/>
         </RadioButton>
 
         <RadioButton Style="{StaticResource ToolBtn}"
                      GroupName="AnnotTool"
                      Tag="Number" Click="Tool_Click" ToolTip="Place numbered label">
-          <Border Width="18" Height="18" BorderBrush="#555" BorderThickness="1.5"
-                  CornerRadius="9" Background="Transparent">
-            <TextBlock Text="1" FontSize="9" FontWeight="Bold"
-                       HorizontalAlignment="Center" VerticalAlignment="Center"
-                       Foreground="#555"/>
-          </Border>
+          <TextBlock Text="①" FontSize="15"/>
         </RadioButton>
 
         <!-- Divider -->

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -23,6 +23,8 @@ public partial class OverlayWindow : Window
     private readonly OverlayViewModel _vm;
     private readonly IScreenCaptureService _screenCapture;
 
+    private int _numberCounter;
+
     private Line? _arrowShaft;
     private Polyline? _arrowHead;
     private Line? _currentLine;
@@ -111,6 +113,7 @@ public partial class OverlayWindow : Window
         {
             ly = y + 4;
         }
+
         Canvas.SetLeft(SizeLabelBorder, x);
         Canvas.SetTop(SizeLabelBorder, ly);
     }
@@ -203,6 +206,7 @@ public partial class OverlayWindow : Window
         {
             left = sel.Left - sz.Width - 8;
         }
+
         top = Math.Max(0, Math.Min(top, Height - sz.Height));
 
         Canvas.SetLeft(AnnotToolbar, left);
@@ -221,6 +225,7 @@ public partial class OverlayWindow : Window
         {
             top = sel.Top - sz.Height - 8;
         }
+
         left = Math.Max(0, Math.Min(left, Width - sz.Width));
         top = Math.Max(0, top);
 
@@ -232,6 +237,8 @@ public partial class OverlayWindow : Window
     {
         var p = e.GetPosition(AnnotationCanvas);
         if (_vm.SelectedTool == AnnotationTool.Text) { PlaceTextBox(p); return; }
+        if (_vm.SelectedTool == AnnotationTool.Number) { PlaceNumberLabel(p); return; }
+
         _vm.BeginDrawing(p);
         AnnotationCanvas.CaptureMouse();
         BeginShape(p);
@@ -319,6 +326,7 @@ public partial class OverlayWindow : Window
                 {
                     _arrowHead.Points.Add(pt);
                 }
+
                 break;
             case LineShapeParameters line when _currentLine != null:
                 _currentLine.X2 = line.P2.X;
@@ -348,6 +356,22 @@ public partial class OverlayWindow : Window
         _arrowShaft = null; _arrowHead = null;
         _currentLine = null; _currentRect = null;
         _currentEllipse = null; _currentPen = null;
+    }
+
+    private void PlaceNumberLabel(Point p)
+    {
+        _numberCounter++;
+        var tb = new TextBlock
+        {
+            Text = $"({_numberCounter})",
+            FontSize = 18,
+            FontWeight = FontWeights.Bold,
+            Foreground = new SolidColorBrush(_vm.ActiveColor),
+            Tag = "number"
+        };
+        Canvas.SetLeft(tb, p.X);
+        Canvas.SetTop(tb, p.Y);
+        AnnotationCanvas.Children.Add(tb);
     }
 
     private void PlaceTextBox(Point p)
@@ -384,6 +408,7 @@ public partial class OverlayWindow : Window
             AnnotationCanvas.Children.Remove(tb);
             return;
         }
+
         var pos = new Point(Canvas.GetLeft(tb), Canvas.GetTop(tb));
         var text = tb.Text;
         var brush = tb.Foreground;
@@ -445,6 +470,7 @@ public partial class OverlayWindow : Window
             dc.DrawImage(screenBmp, r);
             dc.DrawImage(annotRtb, r);
         }
+
         var final = new RenderTargetBitmap(screenBmp.PixelWidth, screenBmp.PixelHeight, 96, 96, PixelFormats.Pbgra32);
         final.Render(dv);
         System.Windows.Clipboard.SetImage(final);

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -3,18 +3,14 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using SnippingTool.Models;
 using SnippingTool.Services;
 using SnippingTool.ViewModels;
-using Brushes = System.Windows.Media.Brushes;
 using Color = System.Windows.Media.Color;
 using Cursors = System.Windows.Input.Cursors;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
-using TextBox = System.Windows.Controls.TextBox;
 
 namespace SnippingTool;
 
@@ -22,15 +18,7 @@ public partial class OverlayWindow : Window
 {
     private readonly OverlayViewModel _vm;
     private readonly IScreenCaptureService _screenCapture;
-
-    private int _numberCounter;
-
-    private Line? _arrowShaft;
-    private Polyline? _arrowHead;
-    private Line? _currentLine;
-    private System.Windows.Shapes.Rectangle? _currentRect;
-    private Ellipse? _currentEllipse;
-    private Polyline? _currentPen;
+    private AnnotationCanvasRenderer _renderer = null!;
 
     public OverlayWindow(OverlayViewModel vm, IScreenCaptureService screenCapture)
     {
@@ -38,6 +26,7 @@ public partial class OverlayWindow : Window
         _screenCapture = screenCapture;
         InitializeComponent();
         DataContext = _vm;
+        _renderer = new AnnotationCanvasRenderer(AnnotationCanvas, _vm, _ => { });
 
         _vm.CopyRequested += DoCopy;
         _vm.CloseRequested += Close;
@@ -135,7 +124,11 @@ public partial class OverlayWindow : Window
         var w = Math.Abs(end.X - start.X);
         var h = Math.Abs(end.Y - start.Y);
 
-        if (w < 4 || h < 4) { Close(); return; }
+        if (w < 4 || h < 4)
+        {
+            Close();
+            return;
+        }
 
         _vm.CommitSelection(new Rect(x, y, w, h));
         TransitionToAnnotating();
@@ -236,12 +229,21 @@ public partial class OverlayWindow : Window
     private void Annot_Down(object sender, MouseButtonEventArgs e)
     {
         var p = e.GetPosition(AnnotationCanvas);
-        if (_vm.SelectedTool == AnnotationTool.Text) { PlaceTextBox(p); return; }
-        if (_vm.SelectedTool == AnnotationTool.Number) { PlaceNumberLabel(p); return; }
+        if (_vm.SelectedTool == AnnotationTool.Text)
+        {
+            _renderer.PlaceTextBox(p);
+            return;
+        }
+
+        if (_vm.SelectedTool == AnnotationTool.Number)
+        {
+            _renderer.PlaceNumberLabel(p);
+            return;
+        }
 
         _vm.BeginDrawing(p);
         AnnotationCanvas.CaptureMouse();
-        BeginShape(p);
+        _renderer.BeginShape(p);
     }
 
     private void Annot_Move(object sender, MouseEventArgs e)
@@ -253,7 +255,7 @@ public partial class OverlayWindow : Window
 
         var p = e.GetPosition(AnnotationCanvas);
         _vm.UpdateDrawing(p);
-        UpdateShape(p);
+        _renderer.UpdateShape(p);
     }
 
     private void Annot_Up(object sender, MouseButtonEventArgs e)
@@ -266,163 +268,8 @@ public partial class OverlayWindow : Window
         var p = e.GetPosition(AnnotationCanvas);
         _vm.UpdateDrawing(p);
         AnnotationCanvas.ReleaseMouseCapture();
-        CommitShape(p);
+        _renderer.CommitShape(p);
         _vm.CommitDrawing();
-    }
-
-    private SolidColorBrush ActiveBrush() => new(_vm.ActiveColor);
-
-    private void BeginShape(Point p)
-    {
-        var thick = _vm.StrokeThickness;
-        switch (_vm.SelectedTool)
-        {
-            case AnnotationTool.Arrow:
-                _arrowShaft = new Line { X1 = p.X, Y1 = p.Y, X2 = p.X, Y2 = p.Y, Stroke = ActiveBrush(), StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                _arrowHead = new Polyline { Stroke = ActiveBrush(), StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeEndLineCap = PenLineCap.Round };
-                AnnotationCanvas.Children.Add(_arrowShaft);
-                AnnotationCanvas.Children.Add(_arrowHead);
-                break;
-            case AnnotationTool.Line:
-                _currentLine = new Line { X1 = p.X, Y1 = p.Y, X2 = p.X, Y2 = p.Y, Stroke = ActiveBrush(), StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                AnnotationCanvas.Children.Add(_currentLine);
-                break;
-            case AnnotationTool.Highlight:
-                var c = _vm.ActiveColor;
-                _currentRect = new System.Windows.Shapes.Rectangle { Fill = new SolidColorBrush(Color.FromArgb(100, c.R, c.G, c.B)) };
-                Canvas.SetLeft(_currentRect, p.X);
-                Canvas.SetTop(_currentRect, p.Y);
-                AnnotationCanvas.Children.Add(_currentRect);
-                break;
-            case AnnotationTool.Rectangle:
-                _currentRect = new System.Windows.Shapes.Rectangle { Stroke = ActiveBrush(), StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentRect, p.X);
-                Canvas.SetTop(_currentRect, p.Y);
-                AnnotationCanvas.Children.Add(_currentRect);
-                break;
-            case AnnotationTool.Pen:
-                _currentPen = new Polyline { Stroke = ActiveBrush(), StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                _currentPen.Points.Add(p);
-                AnnotationCanvas.Children.Add(_currentPen);
-                break;
-            case AnnotationTool.Circle:
-                _currentEllipse = new Ellipse { Stroke = ActiveBrush(), StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentEllipse, p.X);
-                Canvas.SetTop(_currentEllipse, p.Y);
-                AnnotationCanvas.Children.Add(_currentEllipse);
-                break;
-        }
-    }
-
-    private void UpdateShape(Point p)
-    {
-        var @params = _vm.TryGetShapeParameters();
-        if (@params == null)
-        {
-            return;
-        }
-
-        switch (@params)
-        {
-            case ArrowShapeParameters arr when _arrowShaft != null && _arrowHead != null:
-                _arrowShaft.X2 = arr.P2.X;
-                _arrowShaft.Y2 = arr.P2.Y;
-                _arrowHead.Points.Clear();
-                foreach (var pt in arr.ArrowHead)
-                {
-                    _arrowHead.Points.Add(pt);
-                }
-
-                break;
-            case LineShapeParameters line when _currentLine != null:
-                _currentLine.X2 = line.P2.X;
-                _currentLine.Y2 = line.P2.Y;
-                break;
-            case RectShapeParameters rect when _currentRect != null:
-                Canvas.SetLeft(_currentRect, rect.Left);
-                Canvas.SetTop(_currentRect, rect.Top);
-                _currentRect.Width = rect.Width;
-                _currentRect.Height = rect.Height;
-                break;
-            case EllipseShapeParameters ellipse when _currentEllipse != null:
-                Canvas.SetLeft(_currentEllipse, ellipse.Left);
-                Canvas.SetTop(_currentEllipse, ellipse.Top);
-                _currentEllipse.Width = ellipse.Width;
-                _currentEllipse.Height = ellipse.Height;
-                break;
-            case PenShapeParameters when _currentPen != null:
-                _currentPen.Points.Add(p);
-                break;
-        }
-    }
-
-    private void CommitShape(Point p)
-    {
-        UpdateShape(p);
-        _arrowShaft = null; _arrowHead = null;
-        _currentLine = null; _currentRect = null;
-        _currentEllipse = null; _currentPen = null;
-    }
-
-    private void PlaceNumberLabel(Point p)
-    {
-        _numberCounter++;
-        var tb = new TextBlock
-        {
-            Text = $"({_numberCounter})",
-            FontSize = 18,
-            FontWeight = FontWeights.Bold,
-            Foreground = new SolidColorBrush(_vm.ActiveColor),
-            Tag = "number"
-        };
-        Canvas.SetLeft(tb, p.X);
-        Canvas.SetTop(tb, p.Y);
-        AnnotationCanvas.Children.Add(tb);
-    }
-
-    private void PlaceTextBox(Point p)
-    {
-        var tb = new TextBox
-        {
-            Background = Brushes.Transparent,
-            BorderBrush = new SolidColorBrush(Color.FromArgb(80, 0, 0, 0)),
-            BorderThickness = new Thickness(1),
-            Foreground = ActiveBrush(),
-            FontSize = 16,
-            FontWeight = FontWeights.SemiBold,
-            MinWidth = 60,
-            AcceptsReturn = false,
-            Padding = new Thickness(2)
-        };
-        Canvas.SetLeft(tb, p.X);
-        Canvas.SetTop(tb, p.Y);
-        AnnotationCanvas.Children.Add(tb);
-        tb.Focus();
-        tb.KeyDown += (_, ke) => { if (ke.Key is Key.Enter or Key.Escape) { FinalizeTextBox(tb); ke.Handled = true; } };
-        tb.LostFocus += (_, _) => FinalizeTextBox(tb);
-    }
-
-    private void FinalizeTextBox(TextBox tb)
-    {
-        if (!AnnotationCanvas.Children.Contains(tb))
-        {
-            return;
-        }
-
-        if (string.IsNullOrWhiteSpace(tb.Text))
-        {
-            AnnotationCanvas.Children.Remove(tb);
-            return;
-        }
-
-        var pos = new Point(Canvas.GetLeft(tb), Canvas.GetTop(tb));
-        var text = tb.Text;
-        var brush = tb.Foreground;
-        AnnotationCanvas.Children.Remove(tb);
-        var block = new TextBlock { Text = text, Foreground = brush, FontSize = 16, FontWeight = FontWeights.SemiBold };
-        Canvas.SetLeft(block, pos.X);
-        Canvas.SetTop(block, pos.Y);
-        AnnotationCanvas.Children.Add(block);
     }
 
     private void Tool_Click(object sender, RoutedEventArgs e)

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -4,6 +4,9 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
+using SnippingTool.Models;
+using SnippingTool.Services;
+using SnippingTool.ViewModels;
 using Brushes = System.Windows.Media.Brushes;
 using Color = System.Windows.Media.Color;
 using Cursors = System.Windows.Input.Cursors;
@@ -12,8 +15,6 @@ using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 using Point = System.Windows.Point;
 using Size = System.Windows.Size;
 using TextBox = System.Windows.Controls.TextBox;
-using SnippingTool.Services;
-using SnippingTool.ViewModels;
 
 namespace SnippingTool;
 
@@ -22,8 +23,6 @@ public partial class OverlayWindow : Window
     private readonly OverlayViewModel _vm;
     private readonly IScreenCaptureService _screenCapture;
 
-    private bool _annotDragging;
-    private Point _annotStart;
     private Line? _arrowShaft;
     private Polyline? _arrowHead;
     private Line? _currentLine;
@@ -233,32 +232,35 @@ public partial class OverlayWindow : Window
     {
         var p = e.GetPosition(AnnotationCanvas);
         if (_vm.SelectedTool == AnnotationTool.Text) { PlaceTextBox(p); return; }
-        _annotStart = p;
-        _annotDragging = true;
+        _vm.BeginDrawing(p);
         AnnotationCanvas.CaptureMouse();
         BeginShape(p);
     }
 
     private void Annot_Move(object sender, MouseEventArgs e)
     {
-        if (!_annotDragging)
+        if (!_vm.IsDragging)
         {
             return;
         }
 
-        UpdateShape(e.GetPosition(AnnotationCanvas));
+        var p = e.GetPosition(AnnotationCanvas);
+        _vm.UpdateDrawing(p);
+        UpdateShape(p);
     }
 
     private void Annot_Up(object sender, MouseButtonEventArgs e)
     {
-        if (!_annotDragging)
+        if (!_vm.IsDragging)
         {
             return;
         }
 
-        _annotDragging = false;
+        var p = e.GetPosition(AnnotationCanvas);
+        _vm.UpdateDrawing(p);
         AnnotationCanvas.ReleaseMouseCapture();
-        CommitShape(e.GetPosition(AnnotationCanvas));
+        CommitShape(p);
+        _vm.CommitDrawing();
     }
 
     private SolidColorBrush ActiveBrush() => new(_vm.ActiveColor);
@@ -301,29 +303,41 @@ public partial class OverlayWindow : Window
 
     private void UpdateShape(Point p)
     {
-        switch (_vm.SelectedTool)
+        var @params = _vm.TryGetShapeParameters();
+        if (@params == null)
         {
-            case AnnotationTool.Arrow when _arrowShaft != null && _arrowHead != null:
-                _arrowShaft.X2 = p.X; _arrowShaft.Y2 = p.Y;
-                RefreshArrowHead(_arrowShaft, _arrowHead);
+            return;
+        }
+
+        switch (@params)
+        {
+            case ArrowShapeParameters arr when _arrowShaft != null && _arrowHead != null:
+                _arrowShaft.X2 = arr.P2.X;
+                _arrowShaft.Y2 = arr.P2.Y;
+                _arrowHead.Points.Clear();
+                foreach (var pt in arr.ArrowHead)
+                {
+                    _arrowHead.Points.Add(pt);
+                }
                 break;
-            case AnnotationTool.Line when _currentLine != null:
-                _currentLine.X2 = p.X; _currentLine.Y2 = p.Y;
+            case LineShapeParameters line when _currentLine != null:
+                _currentLine.X2 = line.P2.X;
+                _currentLine.Y2 = line.P2.Y;
                 break;
-            case AnnotationTool.Highlight when _currentRect != null:
-                _currentRect.Width = Math.Abs(p.X - _annotStart.X);
-                _currentRect.Height = Math.Abs(p.Y - _annotStart.Y);
-                Canvas.SetLeft(_currentRect, Math.Min(p.X, _annotStart.X));
-                Canvas.SetTop(_currentRect, Math.Min(p.Y, _annotStart.Y));
+            case RectShapeParameters rect when _currentRect != null:
+                Canvas.SetLeft(_currentRect, rect.Left);
+                Canvas.SetTop(_currentRect, rect.Top);
+                _currentRect.Width = rect.Width;
+                _currentRect.Height = rect.Height;
                 break;
-            case AnnotationTool.Pen when _currentPen != null:
+            case EllipseShapeParameters ellipse when _currentEllipse != null:
+                Canvas.SetLeft(_currentEllipse, ellipse.Left);
+                Canvas.SetTop(_currentEllipse, ellipse.Top);
+                _currentEllipse.Width = ellipse.Width;
+                _currentEllipse.Height = ellipse.Height;
+                break;
+            case PenShapeParameters when _currentPen != null:
                 _currentPen.Points.Add(p);
-                break;
-            case AnnotationTool.Circle when _currentEllipse != null:
-                _currentEllipse.Width = Math.Abs(p.X - _annotStart.X);
-                _currentEllipse.Height = Math.Abs(p.Y - _annotStart.Y);
-                Canvas.SetLeft(_currentEllipse, Math.Min(p.X, _annotStart.X));
-                Canvas.SetTop(_currentEllipse, Math.Min(p.Y, _annotStart.Y));
                 break;
         }
     }
@@ -334,17 +348,6 @@ public partial class OverlayWindow : Window
         _arrowShaft = null; _arrowHead = null;
         _currentLine = null; _currentRect = null;
         _currentEllipse = null; _currentPen = null;
-    }
-
-    private static void RefreshArrowHead(Line shaft, Polyline head)
-    {
-        const double headLen = 12.0;
-        const double headAngle = 25.0 * Math.PI / 180.0;
-        var angle = Math.Atan2(shaft.Y2 - shaft.Y1, shaft.X2 - shaft.X1);
-        head.Points.Clear();
-        head.Points.Add(new Point(shaft.X2 - headLen * Math.Cos(angle + headAngle), shaft.Y2 - headLen * Math.Sin(angle + headAngle)));
-        head.Points.Add(new Point(shaft.X2, shaft.Y2));
-        head.Points.Add(new Point(shaft.X2 - headLen * Math.Cos(angle - headAngle), shaft.Y2 - headLen * Math.Sin(angle - headAngle)));
     }
 
     private void PlaceTextBox(Point p)

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -294,6 +294,12 @@ public partial class OverlayWindow : Window
                 Canvas.SetTop(_currentRect, p.Y);
                 AnnotationCanvas.Children.Add(_currentRect);
                 break;
+            case AnnotationTool.Rectangle:
+                _currentRect = new System.Windows.Shapes.Rectangle { Stroke = ActiveBrush(), StrokeThickness = thick, Fill = Brushes.Transparent };
+                Canvas.SetLeft(_currentRect, p.X);
+                Canvas.SetTop(_currentRect, p.Y);
+                AnnotationCanvas.Children.Add(_currentRect);
+                break;
             case AnnotationTool.Pen:
                 _currentPen = new Polyline { Stroke = ActiveBrush(), StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
                 _currentPen.Points.Add(p);

--- a/SnippingTool/PreviewWindow.xaml
+++ b/SnippingTool/PreviewWindow.xaml
@@ -170,7 +170,7 @@
 
               <!-- Arrow -->
               <RadioButton x:Name="ArrowTool" Style="{StaticResource ToolBtn}"
-                           GroupName="Tool" IsChecked="True"
+                           GroupName="Tool"
                            Tag="Arrow" Click="Tool_Click" ToolTip="Draw arrow">
                 <StackPanel>
                   <TextBlock Text="➤" FontSize="13" HorizontalAlignment="Center"/>
@@ -178,12 +178,13 @@
                 </StackPanel>
               </RadioButton>
 
-              <!-- Rectangle -->
+              <!-- Rectangle (outline only) -->
               <RadioButton x:Name="RectTool" Style="{StaticResource ToolBtn}"
-                           GroupName="Tool"
+                           GroupName="Tool" IsChecked="True"
                            Tag="Rectangle" Click="Tool_Click" ToolTip="Draw rectangle">
                 <StackPanel>
-                  <TextBlock Text="▭" FontSize="13" HorizontalAlignment="Center"/>
+                  <Border Width="18" Height="12" BorderBrush="#555" BorderThickness="2"
+                          Background="Transparent" HorizontalAlignment="Center" Margin="0,3,0,1"/>
                   <TextBlock Text="Rect" FontSize="8" Foreground="#666" HorizontalAlignment="Center"/>
                 </StackPanel>
               </RadioButton>
@@ -237,6 +238,22 @@
                 <StackPanel>
                   <TextBlock Text="⬭" FontSize="13" HorizontalAlignment="Center"/>
                   <TextBlock Text="Circle" FontSize="8" Foreground="#666" HorizontalAlignment="Center"/>
+                </StackPanel>
+              </RadioButton>
+
+              <!-- Number -->
+              <RadioButton x:Name="NumberTool" Style="{StaticResource ToolBtn}"
+                           GroupName="Tool"
+                           Tag="Number" Click="Tool_Click" ToolTip="Place numbered label">
+                <StackPanel>
+                  <Border Width="18" Height="18" BorderBrush="#555" BorderThickness="1.5"
+                          CornerRadius="9" Background="Transparent"
+                          HorizontalAlignment="Center" Margin="0,2,0,0">
+                    <TextBlock Text="1" FontSize="9" FontWeight="Bold"
+                               HorizontalAlignment="Center" VerticalAlignment="Center"
+                               Foreground="#555"/>
+                  </Border>
+                  <TextBlock Text="Num" FontSize="8" Foreground="#666" HorizontalAlignment="Center"/>
                 </StackPanel>
               </RadioButton>
 

--- a/SnippingTool/PreviewWindow.xaml.cs
+++ b/SnippingTool/PreviewWindow.xaml.cs
@@ -3,35 +3,23 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
-using System.Windows.Shapes;
-using SnippingTool.Models;
+using SnippingTool.Services;
 using SnippingTool.ViewModels;
-using Brushes = System.Windows.Media.Brushes;
 using Clipboard = System.Windows.Clipboard;
 using Color = System.Windows.Media.Color;
-using Cursors = System.Windows.Input.Cursors;
 using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 using Point = System.Windows.Point;
 using RadioButton = System.Windows.Controls.RadioButton;
 using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
 using Size = System.Windows.Size;
-using TextBox = System.Windows.Controls.TextBox;
 
 namespace SnippingTool;
 
 public partial class PreviewWindow : Window
 {
     private readonly PreviewViewModel _vm;
-
-    private int _numberCounter;
-
-    private Line? _arrowLine;
-    private Polyline? _arrowHead;
-    private System.Windows.Shapes.Rectangle? _currentRect;
-    private Line? _currentLine;
-    private Ellipse? _currentEllipse;
-    private Polyline? _currentPen;
+    private AnnotationCanvasRenderer _renderer = null!;
 
     public PreviewWindow(PreviewViewModel vm, BitmapSource bitmap, System.Windows.Rect snipScreenRect = default)
     {
@@ -46,9 +34,9 @@ public partial class PreviewWindow : Window
                 AnnotationCanvas.Children.Remove(el);
             }
 
-            _numberCounter = AnnotationCanvas.Children
+            _vm.ResetNumberCounter(AnnotationCanvas.Children
                 .OfType<TextBlock>()
-                .Count(tb => tb.Tag is "number");
+                .Count(tb => tb.Tag is "number"));
         };
         _vm.RedoApplied += group =>
         {
@@ -57,13 +45,15 @@ public partial class PreviewWindow : Window
                 AnnotationCanvas.Children.Add(el);
             }
 
-            _numberCounter = AnnotationCanvas.Children
+            _vm.ResetNumberCounter(AnnotationCanvas.Children
                 .OfType<TextBlock>()
-                .Count(tb => tb.Tag is "number");
+                .Count(tb => tb.Tag is "number"));
         };
         _vm.CopyRequested += () => Clipboard.SetImage(RenderComposite());
         _vm.SaveRequested += DoSave;
         _vm.CloseRequested += Close;
+
+        _renderer = new AnnotationCanvasRenderer(AnnotationCanvas, _vm, el => _vm.TrackElement(el));
 
         SnipImage.Source = bitmap;
         AnnotationCanvas.Width = bitmap.PixelWidth;
@@ -113,16 +103,28 @@ public partial class PreviewWindow : Window
 
     private void Window_KeyDown(object sender, KeyEventArgs e)
     {
-        if (e.Key == Key.Escape) { Close(); return; }
+        if (e.Key == Key.Escape)
+        {
+            Close();
+            return;
+        }
 
         if (e.KeyboardDevice.Modifiers == ModifierKeys.Control)
         {
             switch (e.Key)
             {
-                case Key.C: _vm.CopyCommand.Execute(null); break;
-                case Key.S: _vm.SaveCommand.Execute(null); break;
-                case Key.Z: _vm.UndoCommand.Execute(null); break;
-                case Key.Y: _vm.RedoCommand.Execute(null); break;
+                case Key.C:
+                    _vm.CopyCommand.Execute(null);
+                    break;
+                case Key.S:
+                    _vm.SaveCommand.Execute(null);
+                    break;
+                case Key.Z:
+                    _vm.UndoCommand.Execute(null);
+                    break;
+                case Key.Y:
+                    _vm.RedoCommand.Execute(null);
+                    break;
             }
         }
     }
@@ -140,19 +142,7 @@ public partial class PreviewWindow : Window
             return;
         }
 
-        _vm.ActiveColor = border.Tag switch
-        {
-            "Red" => Colors.Red,
-            "Blue" => Colors.DodgerBlue,
-            "Black" => Color.FromRgb(0x1A, 0x1A, 0x1A),
-            "Green" => Color.FromRgb(0x22, 0xA4, 0x22),
-            "Orange" => Colors.Orange,
-            "Purple" => Color.FromRgb(0x8B, 0x2B, 0xE2),
-            "White" => Colors.White,
-            "Pink" => Colors.HotPink,
-            _ => Colors.Red
-        };
-
+        _vm.SetColorFromTag(border.Tag as string);
         ColorIndicator.Fill = _vm.ActiveBrush;
         ColorPopup.IsOpen = false;
     }
@@ -183,9 +173,7 @@ public partial class PreviewWindow : Window
     {
         if (StrokeThickness.SelectedItem is ComboBoxItem item)
         {
-            var text = item.Content?.ToString()?.Split(' ')[0];
-            if (double.TryParse(text, out var t))
-                _vm.StrokeThickness = t;
+            _vm.SetStrokeThicknessFromText(item.Content?.ToString()?.Split(' ')[0]);
         }
     }
 
@@ -199,7 +187,7 @@ public partial class PreviewWindow : Window
 
         if (_vm.SelectedTool == AnnotationTool.Text)
         {
-            PlaceTextBox(pt);
+            _renderer.PlaceTextBox(pt);
             _vm.CommitDrawing();
             _vm.CommitGroup();
             return;
@@ -207,7 +195,7 @@ public partial class PreviewWindow : Window
 
         if (_vm.SelectedTool == AnnotationTool.Number)
         {
-            PlaceNumberLabel(pt);
+            _renderer.PlaceNumberLabel(pt);
             _vm.CommitDrawing();
             _vm.CommitGroup();
             return;
@@ -215,46 +203,7 @@ public partial class PreviewWindow : Window
 
         _vm.BeginDrawing(pt);
         AnnotationCanvas.CaptureMouse();
-
-        var brush = new SolidColorBrush(_vm.ActiveColor);
-        var thick = _vm.StrokeThickness;
-
-        switch (_vm.SelectedTool)
-        {
-            case AnnotationTool.Arrow:
-                _arrowLine = new Line { X1 = pt.X, Y1 = pt.Y, X2 = pt.X, Y2 = pt.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                _arrowHead = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round };
-                AddToCanvas(_arrowLine);
-                AddToCanvas(_arrowHead);
-                break;
-            case AnnotationTool.Rectangle:
-                _currentRect = new System.Windows.Shapes.Rectangle { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentRect, pt.X);
-                Canvas.SetTop(_currentRect, pt.Y);
-                AddToCanvas(_currentRect);
-                break;
-            case AnnotationTool.Highlight:
-                _currentRect = new System.Windows.Shapes.Rectangle { Fill = new SolidColorBrush(Color.FromArgb(80, 255, 255, 0)), Stroke = Brushes.Transparent };
-                Canvas.SetLeft(_currentRect, pt.X);
-                Canvas.SetTop(_currentRect, pt.Y);
-                AddToCanvas(_currentRect);
-                break;
-            case AnnotationTool.Pen:
-                _currentPen = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                _currentPen.Points.Add(pt);
-                AddToCanvas(_currentPen);
-                break;
-            case AnnotationTool.Line:
-                _currentLine = new Line { X1 = pt.X, Y1 = pt.Y, X2 = pt.X, Y2 = pt.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                AddToCanvas(_currentLine);
-                break;
-            case AnnotationTool.Circle:
-                _currentEllipse = new Ellipse { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentEllipse, pt.X);
-                Canvas.SetTop(_currentEllipse, pt.Y);
-                AddToCanvas(_currentEllipse);
-                break;
-        }
+        _renderer.BeginShape(pt);
     }
 
     private void Canvas_MouseMove(object sender, MouseEventArgs e)
@@ -266,45 +215,7 @@ public partial class PreviewWindow : Window
 
         var current = e.GetPosition(AnnotationCanvas);
         _vm.UpdateDrawing(current);
-
-        var @params = _vm.TryGetShapeParameters();
-        if (@params == null)
-        {
-            return;
-        }
-
-        switch (@params)
-        {
-            case ArrowShapeParameters arr when _arrowLine != null && _arrowHead != null:
-                _arrowLine.X2 = arr.P2.X;
-                _arrowLine.Y2 = arr.P2.Y;
-                _arrowHead.Points.Clear();
-                foreach (var pt in arr.ArrowHead)
-                {
-                    _arrowHead.Points.Add(pt);
-                }
-
-                break;
-            case RectShapeParameters rect when _currentRect != null:
-                Canvas.SetLeft(_currentRect, rect.Left);
-                Canvas.SetTop(_currentRect, rect.Top);
-                _currentRect.Width = rect.Width;
-                _currentRect.Height = rect.Height;
-                break;
-            case EllipseShapeParameters ellipse when _currentEllipse != null:
-                Canvas.SetLeft(_currentEllipse, ellipse.Left);
-                Canvas.SetTop(_currentEllipse, ellipse.Top);
-                _currentEllipse.Width = ellipse.Width;
-                _currentEllipse.Height = ellipse.Height;
-                break;
-            case LineShapeParameters line when _currentLine != null:
-                _currentLine.X2 = line.P2.X;
-                _currentLine.Y2 = line.P2.Y;
-                break;
-            case PenShapeParameters when _currentPen != null:
-                _currentPen.Points.Add(current);
-                break;
-        }
+        _renderer.UpdateShape(current);
     }
 
     private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
@@ -317,69 +228,9 @@ public partial class PreviewWindow : Window
         var current = e.GetPosition(AnnotationCanvas);
         _vm.UpdateDrawing(current);
         AnnotationCanvas.ReleaseMouseCapture();
-
-        // Final arrow head update
-        if (_vm.SelectedTool == AnnotationTool.Arrow && _arrowLine != null && _arrowHead != null)
-        {
-            var head = _vm.TryGetShapeParameters() as ArrowShapeParameters;
-            if (head != null)
-            {
-                _arrowHead.Points.Clear();
-                foreach (var pt in head.ArrowHead)
-                {
-                    _arrowHead.Points.Add(pt);
-                }
-            }
-        }
-
+        _renderer.CommitShape(current);
         _vm.CommitDrawing();
-
-        _arrowLine = null; _arrowHead = null;
-        _currentRect = null; _currentLine = null;
-        _currentEllipse = null; _currentPen = null;
-
         _vm.CommitGroup();
-    }
-
-    private void AddToCanvas(UIElement element)
-    {
-        AnnotationCanvas.Children.Add(element);
-        _vm.TrackElement(element);
-    }
-
-    private void PlaceTextBox(Point position)
-    {
-        var tb = new TextBox
-        {
-            FontSize = 16,
-            Foreground = new SolidColorBrush(_vm.ActiveColor),
-            Background = Brushes.Transparent,
-            BorderThickness = new Thickness(1),
-            BorderBrush = Brushes.Gray,
-            MinWidth = 80,
-            AcceptsReturn = false
-        };
-        tb.LostFocus += (_, _) => { tb.IsReadOnly = true; tb.BorderThickness = new Thickness(0); tb.Cursor = Cursors.Arrow; };
-        Canvas.SetLeft(tb, position.X);
-        Canvas.SetTop(tb, position.Y);
-        AddToCanvas(tb);
-        tb.Focus();
-    }
-
-    private void PlaceNumberLabel(Point position)
-    {
-        _numberCounter++;
-        var tb = new TextBlock
-        {
-            Text = $"({_numberCounter})",
-            FontSize = 18,
-            FontWeight = FontWeights.Bold,
-            Foreground = new SolidColorBrush(_vm.ActiveColor),
-            Tag = "number"
-        };
-        Canvas.SetLeft(tb, position.X);
-        Canvas.SetTop(tb, position.Y);
-        AddToCanvas(tb);
     }
 
     private void Copy_Click(object sender, RoutedEventArgs e) => _vm.CopyCommand.Execute(null);

--- a/SnippingTool/PreviewWindow.xaml.cs
+++ b/SnippingTool/PreviewWindow.xaml.cs
@@ -46,6 +46,7 @@ public partial class PreviewWindow : Window
             {
                 AnnotationCanvas.Children.Remove(el);
             }
+
             _numberCounter = AnnotationCanvas.Children
                 .OfType<TextBlock>()
                 .Count(tb => tb.Tag is "number");
@@ -56,6 +57,7 @@ public partial class PreviewWindow : Window
             {
                 AnnotationCanvas.Children.Add(el);
             }
+
             _numberCounter = AnnotationCanvas.Children
                 .OfType<TextBlock>()
                 .Count(tb => tb.Tag is "number");
@@ -88,11 +90,13 @@ public partial class PreviewWindow : Window
         {
             left = workArea.Right - Width;
         }
+
         left = Math.Max(workArea.Left, left);
         if (top + Height > workArea.Bottom)
         {
             top = snip.Top - Height - gap;
         }
+
         top = Math.Max(workArea.Top, top);
         Left = left;
         Top = top;
@@ -280,6 +284,7 @@ public partial class PreviewWindow : Window
                 {
                     _arrowHead.Points.Add(pt);
                 }
+
                 break;
             case RectShapeParameters rect when _currentRect != null:
                 Canvas.SetLeft(_currentRect, rect.Left);

--- a/SnippingTool/PreviewWindow.xaml.cs
+++ b/SnippingTool/PreviewWindow.xaml.cs
@@ -4,7 +4,6 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
-using Microsoft.Win32;
 using SnippingTool.Models;
 using SnippingTool.ViewModels;
 using Brushes = System.Windows.Media.Brushes;

--- a/SnippingTool/PreviewWindow.xaml.cs
+++ b/SnippingTool/PreviewWindow.xaml.cs
@@ -5,6 +5,8 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using Microsoft.Win32;
+using SnippingTool.Models;
+using SnippingTool.ViewModels;
 using Brushes = System.Windows.Media.Brushes;
 using Clipboard = System.Windows.Clipboard;
 using Color = System.Windows.Media.Color;
@@ -16,18 +18,14 @@ using RadioButton = System.Windows.Controls.RadioButton;
 using SaveFileDialog = Microsoft.Win32.SaveFileDialog;
 using Size = System.Windows.Size;
 using TextBox = System.Windows.Controls.TextBox;
-using SnippingTool.ViewModels;
 
 namespace SnippingTool;
-
-public enum AnnotationTool { Arrow, Rectangle, Text, Highlight, Pen, Line, Circle }
 
 public partial class PreviewWindow : Window
 {
     private readonly PreviewViewModel _vm;
 
-    private bool _isDragging;
-    private Point _dragStart;
+    private int _numberCounter;
 
     private Line? _arrowLine;
     private Polyline? _arrowHead;
@@ -45,12 +43,22 @@ public partial class PreviewWindow : Window
         _vm.UndoApplied += group =>
         {
             foreach (var el in group.Cast<UIElement>())
+            {
                 AnnotationCanvas.Children.Remove(el);
+            }
+            _numberCounter = AnnotationCanvas.Children
+                .OfType<TextBlock>()
+                .Count(tb => tb.Tag is "number");
         };
         _vm.RedoApplied += group =>
         {
             foreach (var el in group.Cast<UIElement>())
+            {
                 AnnotationCanvas.Children.Add(el);
+            }
+            _numberCounter = AnnotationCanvas.Children
+                .OfType<TextBlock>()
+                .Count(tb => tb.Tag is "number");
         };
         _vm.CopyRequested += () => Clipboard.SetImage(RenderComposite());
         _vm.SaveRequested += DoSave;
@@ -183,19 +191,27 @@ public partial class PreviewWindow : Window
 
     private void Canvas_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
     {
-        _dragStart = e.GetPosition(AnnotationCanvas);
-        _isDragging = true;
-        AnnotationCanvas.CaptureMouse();
+        var pt = e.GetPosition(AnnotationCanvas);
         _vm.BeginGroup();
 
         if (_vm.SelectedTool == AnnotationTool.Text)
         {
-            PlaceTextBox(_dragStart);
-            _isDragging = false;
-            AnnotationCanvas.ReleaseMouseCapture();
+            PlaceTextBox(pt);
+            _vm.CommitDrawing();
             _vm.CommitGroup();
             return;
         }
+
+        if (_vm.SelectedTool == AnnotationTool.Number)
+        {
+            PlaceNumberLabel(pt);
+            _vm.CommitDrawing();
+            _vm.CommitGroup();
+            return;
+        }
+
+        _vm.BeginDrawing(pt);
+        AnnotationCanvas.CaptureMouse();
 
         var brush = new SolidColorBrush(_vm.ActiveColor);
         var thick = _vm.StrokeThickness;
@@ -203,36 +219,36 @@ public partial class PreviewWindow : Window
         switch (_vm.SelectedTool)
         {
             case AnnotationTool.Arrow:
-                _arrowLine = new Line { X1 = _dragStart.X, Y1 = _dragStart.Y, X2 = _dragStart.X, Y2 = _dragStart.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
+                _arrowLine = new Line { X1 = pt.X, Y1 = pt.Y, X2 = pt.X, Y2 = pt.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
                 _arrowHead = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round };
                 AddToCanvas(_arrowLine);
                 AddToCanvas(_arrowHead);
                 break;
             case AnnotationTool.Rectangle:
                 _currentRect = new System.Windows.Shapes.Rectangle { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentRect, _dragStart.X);
-                Canvas.SetTop(_currentRect, _dragStart.Y);
+                Canvas.SetLeft(_currentRect, pt.X);
+                Canvas.SetTop(_currentRect, pt.Y);
                 AddToCanvas(_currentRect);
                 break;
             case AnnotationTool.Highlight:
                 _currentRect = new System.Windows.Shapes.Rectangle { Fill = new SolidColorBrush(Color.FromArgb(80, 255, 255, 0)), Stroke = Brushes.Transparent };
-                Canvas.SetLeft(_currentRect, _dragStart.X);
-                Canvas.SetTop(_currentRect, _dragStart.Y);
+                Canvas.SetLeft(_currentRect, pt.X);
+                Canvas.SetTop(_currentRect, pt.Y);
                 AddToCanvas(_currentRect);
                 break;
             case AnnotationTool.Pen:
                 _currentPen = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
-                _currentPen.Points.Add(_dragStart);
+                _currentPen.Points.Add(pt);
                 AddToCanvas(_currentPen);
                 break;
             case AnnotationTool.Line:
-                _currentLine = new Line { X1 = _dragStart.X, Y1 = _dragStart.Y, X2 = _dragStart.X, Y2 = _dragStart.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
+                _currentLine = new Line { X1 = pt.X, Y1 = pt.Y, X2 = pt.X, Y2 = pt.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
                 AddToCanvas(_currentLine);
                 break;
             case AnnotationTool.Circle:
                 _currentEllipse = new Ellipse { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
-                Canvas.SetLeft(_currentEllipse, _dragStart.X);
-                Canvas.SetTop(_currentEllipse, _dragStart.Y);
+                Canvas.SetLeft(_currentEllipse, pt.X);
+                Canvas.SetTop(_currentEllipse, pt.Y);
                 AddToCanvas(_currentEllipse);
                 break;
         }
@@ -240,30 +256,48 @@ public partial class PreviewWindow : Window
 
     private void Canvas_MouseMove(object sender, MouseEventArgs e)
     {
-        if (!_isDragging)
+        if (!_vm.IsDragging)
         {
             return;
         }
 
         var current = e.GetPosition(AnnotationCanvas);
+        _vm.UpdateDrawing(current);
 
-        switch (_vm.SelectedTool)
+        var @params = _vm.TryGetShapeParameters();
+        if (@params == null)
         {
-            case AnnotationTool.Arrow when _arrowLine != null:
-                _arrowLine.X2 = current.X; _arrowLine.Y2 = current.Y;
-                UpdateArrowHead(_arrowLine, _arrowHead!);
+            return;
+        }
+
+        switch (@params)
+        {
+            case ArrowShapeParameters arr when _arrowLine != null && _arrowHead != null:
+                _arrowLine.X2 = arr.P2.X;
+                _arrowLine.Y2 = arr.P2.Y;
+                _arrowHead.Points.Clear();
+                foreach (var pt in arr.ArrowHead)
+                {
+                    _arrowHead.Points.Add(pt);
+                }
                 break;
-            case AnnotationTool.Rectangle when _currentRect != null:
-            case AnnotationTool.Highlight when _currentRect != null:
-                UpdateRect(_currentRect, _dragStart, current);
+            case RectShapeParameters rect when _currentRect != null:
+                Canvas.SetLeft(_currentRect, rect.Left);
+                Canvas.SetTop(_currentRect, rect.Top);
+                _currentRect.Width = rect.Width;
+                _currentRect.Height = rect.Height;
                 break;
-            case AnnotationTool.Circle when _currentEllipse != null:
-                UpdateEllipse(_currentEllipse, _dragStart, current);
+            case EllipseShapeParameters ellipse when _currentEllipse != null:
+                Canvas.SetLeft(_currentEllipse, ellipse.Left);
+                Canvas.SetTop(_currentEllipse, ellipse.Top);
+                _currentEllipse.Width = ellipse.Width;
+                _currentEllipse.Height = ellipse.Height;
                 break;
-            case AnnotationTool.Line when _currentLine != null:
-                _currentLine.X2 = current.X; _currentLine.Y2 = current.Y;
+            case LineShapeParameters line when _currentLine != null:
+                _currentLine.X2 = line.P2.X;
+                _currentLine.Y2 = line.P2.Y;
                 break;
-            case AnnotationTool.Pen when _currentPen != null:
+            case PenShapeParameters when _currentPen != null:
                 _currentPen.Points.Add(current);
                 break;
         }
@@ -271,16 +305,30 @@ public partial class PreviewWindow : Window
 
     private void Canvas_MouseLeftButtonUp(object sender, MouseButtonEventArgs e)
     {
-        if (!_isDragging)
+        if (!_vm.IsDragging)
         {
             return;
         }
 
-        _isDragging = false;
+        var current = e.GetPosition(AnnotationCanvas);
+        _vm.UpdateDrawing(current);
         AnnotationCanvas.ReleaseMouseCapture();
 
-        if (_vm.SelectedTool == AnnotationTool.Arrow && _arrowLine != null)
-            UpdateArrowHead(_arrowLine, _arrowHead!);
+        // Final arrow head update
+        if (_vm.SelectedTool == AnnotationTool.Arrow && _arrowLine != null && _arrowHead != null)
+        {
+            var head = _vm.TryGetShapeParameters() as ArrowShapeParameters;
+            if (head != null)
+            {
+                _arrowHead.Points.Clear();
+                foreach (var pt in head.ArrowHead)
+                {
+                    _arrowHead.Points.Add(pt);
+                }
+            }
+        }
+
+        _vm.CommitDrawing();
 
         _arrowLine = null; _arrowHead = null;
         _currentRect = null; _currentLine = null;
@@ -293,33 +341,6 @@ public partial class PreviewWindow : Window
     {
         AnnotationCanvas.Children.Add(element);
         _vm.TrackElement(element);
-    }
-
-    private static void UpdateRect(System.Windows.Shapes.Rectangle rect, Point start, Point end)
-    {
-        Canvas.SetLeft(rect, Math.Min(start.X, end.X));
-        Canvas.SetTop(rect, Math.Min(start.Y, end.Y));
-        rect.Width = Math.Abs(end.X - start.X);
-        rect.Height = Math.Abs(end.Y - start.Y);
-    }
-
-    private static void UpdateEllipse(Ellipse ellipse, Point start, Point end)
-    {
-        Canvas.SetLeft(ellipse, Math.Min(start.X, end.X));
-        Canvas.SetTop(ellipse, Math.Min(start.Y, end.Y));
-        ellipse.Width = Math.Abs(end.X - start.X);
-        ellipse.Height = Math.Abs(end.Y - start.Y);
-    }
-
-    private static void UpdateArrowHead(Line line, Polyline head)
-    {
-        const double headLen = 14;
-        const double angle = 25 * Math.PI / 180;
-        var theta = Math.Atan2(line.Y2 - line.Y1, line.X2 - line.X1);
-        head.Points.Clear();
-        head.Points.Add(new Point(line.X2 - headLen * Math.Cos(theta - angle), line.Y2 - headLen * Math.Sin(theta - angle)));
-        head.Points.Add(new Point(line.X2, line.Y2));
-        head.Points.Add(new Point(line.X2 - headLen * Math.Cos(theta + angle), line.Y2 - headLen * Math.Sin(theta + angle)));
     }
 
     private void PlaceTextBox(Point position)
@@ -339,6 +360,22 @@ public partial class PreviewWindow : Window
         Canvas.SetTop(tb, position.Y);
         AddToCanvas(tb);
         tb.Focus();
+    }
+
+    private void PlaceNumberLabel(Point position)
+    {
+        _numberCounter++;
+        var tb = new TextBlock
+        {
+            Text = $"({_numberCounter})",
+            FontSize = 18,
+            FontWeight = FontWeights.Bold,
+            Foreground = new SolidColorBrush(_vm.ActiveColor),
+            Tag = "number"
+        };
+        Canvas.SetLeft(tb, position.X);
+        Canvas.SetTop(tb, position.Y);
+        AddToCanvas(tb);
     }
 
     private void Copy_Click(object sender, RoutedEventArgs e) => _vm.CopyCommand.Execute(null);

--- a/SnippingTool/Services/AnnotationCanvasRenderer.cs
+++ b/SnippingTool/Services/AnnotationCanvasRenderer.cs
@@ -1,0 +1,211 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Shapes;
+using SnippingTool.Models;
+using SnippingTool.ViewModels;
+using Brushes = System.Windows.Media.Brushes;
+using Color = System.Windows.Media.Color;
+using Cursors = System.Windows.Input.Cursors;
+using Point = System.Windows.Point;
+using TextBox = System.Windows.Controls.TextBox;
+
+namespace SnippingTool.Services;
+
+internal sealed class AnnotationCanvasRenderer
+{
+    private readonly Canvas _canvas;
+    private readonly AnnotationViewModel _vm;
+    private readonly Action<UIElement> _onAdd;
+
+    private Line? _arrowShaft;
+    private Polyline? _arrowHead;
+    private Line? _currentLine;
+    private System.Windows.Shapes.Rectangle? _currentRect;
+    private Ellipse? _currentEllipse;
+    private Polyline? _currentPen;
+
+    public AnnotationCanvasRenderer(Canvas canvas, AnnotationViewModel vm, Action<UIElement> onAdd)
+    {
+        _canvas = canvas;
+        _vm = vm;
+        _onAdd = onAdd;
+    }
+
+    private SolidColorBrush ActiveBrush() => new(_vm.ActiveColor);
+
+    public void BeginShape(Point p)
+    {
+        var brush = ActiveBrush();
+        var thick = _vm.StrokeThickness;
+
+        switch (_vm.SelectedTool)
+        {
+            case AnnotationTool.Arrow:
+                _arrowShaft = new Line { X1 = p.X, Y1 = p.Y, X2 = p.X, Y2 = p.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
+                _arrowHead = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeEndLineCap = PenLineCap.Round };
+                Add(_arrowShaft);
+                Add(_arrowHead);
+                break;
+            case AnnotationTool.Line:
+                _currentLine = new Line { X1 = p.X, Y1 = p.Y, X2 = p.X, Y2 = p.Y, Stroke = brush, StrokeThickness = thick, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
+                Add(_currentLine);
+                break;
+            case AnnotationTool.Rectangle:
+                _currentRect = new System.Windows.Shapes.Rectangle { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
+                Canvas.SetLeft(_currentRect, p.X);
+                Canvas.SetTop(_currentRect, p.Y);
+                Add(_currentRect);
+                break;
+            case AnnotationTool.Highlight:
+                var c = _vm.ActiveColor;
+                _currentRect = new System.Windows.Shapes.Rectangle { Fill = new SolidColorBrush(Color.FromArgb(100, c.R, c.G, c.B)) };
+                Canvas.SetLeft(_currentRect, p.X);
+                Canvas.SetTop(_currentRect, p.Y);
+                Add(_currentRect);
+                break;
+            case AnnotationTool.Pen:
+                _currentPen = new Polyline { Stroke = brush, StrokeThickness = thick, StrokeLineJoin = PenLineJoin.Round, StrokeStartLineCap = PenLineCap.Round, StrokeEndLineCap = PenLineCap.Round };
+                _currentPen.Points.Add(p);
+                Add(_currentPen);
+                break;
+            case AnnotationTool.Circle:
+                _currentEllipse = new Ellipse { Stroke = brush, StrokeThickness = thick, Fill = Brushes.Transparent };
+                Canvas.SetLeft(_currentEllipse, p.X);
+                Canvas.SetTop(_currentEllipse, p.Y);
+                Add(_currentEllipse);
+                break;
+        }
+    }
+
+    public void UpdateShape(Point p)
+    {
+        var @params = _vm.TryGetShapeParameters();
+        if (@params == null)
+        {
+            return;
+        }
+
+        switch (@params)
+        {
+            case ArrowShapeParameters arr when _arrowShaft != null && _arrowHead != null:
+                _arrowShaft.X2 = arr.P2.X;
+                _arrowShaft.Y2 = arr.P2.Y;
+                _arrowHead.Points.Clear();
+                foreach (var pt in arr.ArrowHead)
+                {
+                    _arrowHead.Points.Add(pt);
+                }
+                break;
+            case LineShapeParameters line when _currentLine != null:
+                _currentLine.X2 = line.P2.X;
+                _currentLine.Y2 = line.P2.Y;
+                break;
+            case RectShapeParameters rect when _currentRect != null:
+                Canvas.SetLeft(_currentRect, rect.Left);
+                Canvas.SetTop(_currentRect, rect.Top);
+                _currentRect.Width = rect.Width;
+                _currentRect.Height = rect.Height;
+                break;
+            case EllipseShapeParameters ellipse when _currentEllipse != null:
+                Canvas.SetLeft(_currentEllipse, ellipse.Left);
+                Canvas.SetTop(_currentEllipse, ellipse.Top);
+                _currentEllipse.Width = ellipse.Width;
+                _currentEllipse.Height = ellipse.Height;
+                break;
+            case PenShapeParameters when _currentPen != null:
+                _currentPen.Points.Add(p);
+                break;
+        }
+    }
+
+    public void CommitShape(Point p)
+    {
+        UpdateShape(p);
+        _arrowShaft = null;
+        _arrowHead = null;
+        _currentLine = null;
+        _currentRect = null;
+        _currentEllipse = null;
+        _currentPen = null;
+    }
+
+    public void PlaceNumberLabel(Point p)
+    {
+        var n = _vm.IncrementNumberCounter();
+        var tb = new TextBlock
+        {
+            Text = $"({n})",
+            FontSize = 18,
+            FontWeight = FontWeights.Bold,
+            Foreground = ActiveBrush(),
+            Tag = "number"
+        };
+        Canvas.SetLeft(tb, p.X);
+        Canvas.SetTop(tb, p.Y);
+        Add(tb);
+    }
+
+    public void PlaceTextBox(Point p)
+    {
+        var tb = new TextBox
+        {
+            FontSize = 16,
+            Foreground = ActiveBrush(),
+            Background = Brushes.Transparent,
+            BorderThickness = new Thickness(1),
+            BorderBrush = Brushes.Gray,
+            MinWidth = 80,
+            AcceptsReturn = false,
+            Padding = new Thickness(2)
+        };
+        tb.LostFocus += (_, _) =>
+        {
+            tb.IsReadOnly = true;
+            tb.BorderThickness = new Thickness(0);
+            tb.Cursor = Cursors.Arrow;
+        };
+        tb.KeyDown += (_, ke) =>
+        {
+            if (ke.Key is Key.Enter or Key.Escape)
+            {
+                FinalizeTextBox(tb);
+                ke.Handled = true;
+            }
+        };
+        Canvas.SetLeft(tb, p.X);
+        Canvas.SetTop(tb, p.Y);
+        Add(tb);
+        tb.Focus();
+    }
+
+    private void FinalizeTextBox(TextBox tb)
+    {
+        if (!_canvas.Children.Contains(tb))
+        {
+            return;
+        }
+
+        if (string.IsNullOrWhiteSpace(tb.Text))
+        {
+            _canvas.Children.Remove(tb);
+            return;
+        }
+
+        var pos = new Point(Canvas.GetLeft(tb), Canvas.GetTop(tb));
+        var text = tb.Text;
+        var brush = tb.Foreground;
+        _canvas.Children.Remove(tb);
+        var block = new TextBlock { Text = text, Foreground = brush, FontSize = 16, FontWeight = FontWeights.SemiBold };
+        Canvas.SetLeft(block, pos.X);
+        Canvas.SetTop(block, pos.Y);
+        Add(block);
+    }
+
+    private void Add(UIElement element)
+    {
+        _canvas.Children.Add(element);
+        _onAdd(element);
+    }
+}

--- a/SnippingTool/Services/AnnotationGeometryService.cs
+++ b/SnippingTool/Services/AnnotationGeometryService.cs
@@ -1,0 +1,40 @@
+using System.Windows;
+using Point = System.Windows.Point;
+
+namespace SnippingTool.Services;
+
+public class AnnotationGeometryService : IAnnotationGeometryService
+{
+    private const double HeadLength = 14.0;
+    private const double HeadAngle = 25.0 * Math.PI / 180.0;
+
+    public Point[] CalculateArrowHead(Point p1, Point p2)
+    {
+        var theta = Math.Atan2(p2.Y - p1.Y, p2.X - p1.X);
+        return
+        [
+            new Point(p2.X - HeadLength * Math.Cos(theta - HeadAngle), p2.Y - HeadLength * Math.Sin(theta - HeadAngle)),
+            p2,
+            new Point(p2.X - HeadLength * Math.Cos(theta + HeadAngle), p2.Y - HeadLength * Math.Sin(theta + HeadAngle))
+        ];
+    }
+
+    public (double left, double top, double width, double height) CalculateRect(Point start, Point end)
+    {
+        var left = Math.Min(start.X, end.X);
+        var top = Math.Min(start.Y, end.Y);
+        var width = Math.Abs(end.X - start.X);
+        var height = Math.Abs(end.Y - start.Y);
+        return (left, top, width, height);
+    }
+
+    public (double left, double top, double width, double height) CalculateEllipse(Point start, Point end)
+        => CalculateRect(start, end);
+
+    public bool IsValidShapeSize(Point start, Point end, double minSide = 4.0)
+    {
+        var width = Math.Abs(end.X - start.X);
+        var height = Math.Abs(end.Y - start.Y);
+        return Math.Max(width, height) >= minSide;
+    }
+}

--- a/SnippingTool/Services/AnnotationGeometryService.cs
+++ b/SnippingTool/Services/AnnotationGeometryService.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using Point = System.Windows.Point;
 
 namespace SnippingTool.Services;

--- a/SnippingTool/Services/IAnnotationGeometryService.cs
+++ b/SnippingTool/Services/IAnnotationGeometryService.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+using Point = System.Windows.Point;
+
+namespace SnippingTool.Services;
+
+public interface IAnnotationGeometryService
+{
+    Point[] CalculateArrowHead(Point p1, Point p2);
+    (double left, double top, double width, double height) CalculateRect(Point start, Point end);
+    (double left, double top, double width, double height) CalculateEllipse(Point start, Point end);
+    bool IsValidShapeSize(Point start, Point end, double minSide = 4.0);
+}

--- a/SnippingTool/Services/IAnnotationGeometryService.cs
+++ b/SnippingTool/Services/IAnnotationGeometryService.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using Point = System.Windows.Point;
 
 namespace SnippingTool.Services;

--- a/SnippingTool/ViewModels/AnnotationViewModel.cs
+++ b/SnippingTool/ViewModels/AnnotationViewModel.cs
@@ -29,8 +29,6 @@ public partial class AnnotationViewModel : ObservableObject
 
     partial void OnActiveColorChanged(Color value) => OnPropertyChanged(nameof(ActiveBrush));
 
-    // ── Drawing state machine ──────────────────────────────────────────────
-
     public bool IsDragging { get; private set; }
     public Point DragStart { get; private set; }
     public Point DragCurrent { get; private set; }
@@ -55,6 +53,43 @@ public partial class AnnotationViewModel : ObservableObject
     public void CancelDrawing()
     {
         IsDragging = false;
+    }
+
+    public int NumberCounter { get; private set; }
+
+    public int IncrementNumberCounter()
+    {
+        NumberCounter++;
+        return NumberCounter;
+    }
+
+    public void ResetNumberCounter(int value)
+    {
+        NumberCounter = value;
+    }
+
+    public void SetColorFromTag(string? tag)
+    {
+        ActiveColor = tag switch
+        {
+            "Red" => Colors.Red,
+            "Blue" => Colors.DodgerBlue,
+            "Black" => Color.FromRgb(0x1A, 0x1A, 0x1A),
+            "Green" => Color.FromRgb(0x22, 0xA4, 0x22),
+            "Orange" => Colors.Orange,
+            "Purple" => Color.FromRgb(0x8B, 0x2B, 0xE2),
+            "White" => Colors.White,
+            "Pink" => Colors.HotPink,
+            _ => Colors.Red
+        };
+    }
+
+    public void SetStrokeThicknessFromText(string? text)
+    {
+        if (double.TryParse(text, out var t))
+        {
+            StrokeThickness = t;
+        }
     }
 
     public ShapeParameters? TryGetShapeParameters()

--- a/SnippingTool/ViewModels/AnnotationViewModel.cs
+++ b/SnippingTool/ViewModels/AnnotationViewModel.cs
@@ -1,4 +1,3 @@
-using System.Windows;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
 using SnippingTool.Models;

--- a/SnippingTool/ViewModels/AnnotationViewModel.cs
+++ b/SnippingTool/ViewModels/AnnotationViewModel.cs
@@ -1,13 +1,24 @@
+using System.Windows;
 using System.Windows.Media;
 using CommunityToolkit.Mvvm.ComponentModel;
+using SnippingTool.Models;
+using SnippingTool.Services;
 using Color = System.Windows.Media.Color;
+using Point = System.Windows.Point;
 
 namespace SnippingTool.ViewModels;
 
 public partial class AnnotationViewModel : ObservableObject
 {
+    private readonly IAnnotationGeometryService _geometry;
+
+    public AnnotationViewModel(IAnnotationGeometryService geometry)
+    {
+        _geometry = geometry;
+    }
+
     [ObservableProperty]
-    private AnnotationTool _selectedTool = AnnotationTool.Arrow;
+    private AnnotationTool _selectedTool = AnnotationTool.Rectangle;
 
     [ObservableProperty]
     private Color _activeColor = Colors.Red;
@@ -18,4 +29,84 @@ public partial class AnnotationViewModel : ObservableObject
     public SolidColorBrush ActiveBrush => new(ActiveColor);
 
     partial void OnActiveColorChanged(Color value) => OnPropertyChanged(nameof(ActiveBrush));
+
+    // ── Drawing state machine ──────────────────────────────────────────────
+
+    public bool IsDragging { get; private set; }
+    public Point DragStart { get; private set; }
+    public Point DragCurrent { get; private set; }
+
+    public void BeginDrawing(Point pt)
+    {
+        DragStart = pt;
+        DragCurrent = pt;
+        IsDragging = true;
+    }
+
+    public void UpdateDrawing(Point pt)
+    {
+        DragCurrent = pt;
+    }
+
+    public void CommitDrawing()
+    {
+        IsDragging = false;
+    }
+
+    public void CancelDrawing()
+    {
+        IsDragging = false;
+    }
+
+    public ShapeParameters? TryGetShapeParameters()
+    {
+        if (!_geometry.IsValidShapeSize(DragStart, DragCurrent))
+        {
+            return null;
+        }
+
+        var color = ActiveColor;
+        var thick = StrokeThickness;
+
+        return SelectedTool switch
+        {
+            AnnotationTool.Arrow => new ArrowShapeParameters(
+                P1: DragStart,
+                P2: DragCurrent,
+                Color: color,
+                Thickness: thick,
+                ArrowHead: _geometry.CalculateArrowHead(DragStart, DragCurrent)),
+
+            AnnotationTool.Rectangle => BuildRectParams(DragStart, DragCurrent, color, thick, isHighlight: false),
+
+            AnnotationTool.Highlight => BuildRectParams(DragStart, DragCurrent, color, thick, isHighlight: true),
+
+            AnnotationTool.Circle => BuildEllipseParams(DragStart, DragCurrent, color, thick),
+
+            AnnotationTool.Line => new LineShapeParameters(
+                P1: DragStart,
+                P2: DragCurrent,
+                Color: color,
+                Thickness: thick),
+
+            AnnotationTool.Pen => new PenShapeParameters(
+                StartPoint: DragStart,
+                Color: color,
+                Thickness: thick),
+
+            _ => null
+        };
+    }
+
+    private RectShapeParameters BuildRectParams(Point start, Point end, Color color, double thick, bool isHighlight)
+    {
+        var (left, top, width, height) = _geometry.CalculateRect(start, end);
+        return new RectShapeParameters(left, top, width, height, color, thick, isHighlight);
+    }
+
+    private EllipseShapeParameters BuildEllipseParams(Point start, Point end, Color color, double thick)
+    {
+        var (left, top, width, height) = _geometry.CalculateEllipse(start, end);
+        return new EllipseShapeParameters(left, top, width, height, color, thick);
+    }
 }

--- a/SnippingTool/ViewModels/OverlayViewModel.cs
+++ b/SnippingTool/ViewModels/OverlayViewModel.cs
@@ -1,11 +1,14 @@
 using System.Windows;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SnippingTool.Services;
 
 namespace SnippingTool.ViewModels;
 
 public partial class OverlayViewModel : AnnotationViewModel
 {
+    public OverlayViewModel(IAnnotationGeometryService geometry) : base(geometry) { }
+
     public enum Phase { Selecting, Annotating }
 
     [ObservableProperty]

--- a/SnippingTool/ViewModels/PreviewViewModel.cs
+++ b/SnippingTool/ViewModels/PreviewViewModel.cs
@@ -1,10 +1,13 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using SnippingTool.Services;
 
 namespace SnippingTool.ViewModels;
 
 public partial class PreviewViewModel : AnnotationViewModel
 {
+    public PreviewViewModel(IAnnotationGeometryService geometry) : base(geometry) { }
+
     private readonly List<List<object>> _undoStack = [];
     private readonly List<List<object>> _redoStack = [];
     private List<object>? _currentGroup;


### PR DESCRIPTION
Centralize annotation geometry in IAnnotationGeometryService and refactor drawing state management into view models. Remove geometry code from UI; all shape updates now use shape parameters from the view model. Add "Number" annotation tool and update UI. Inject geometry service via DI. Add comprehensive unit tests for geometry and view model logic. Improves maintainability, testability, and extensibility.