### PR TITLE
Remove System.Drawing.Common

### DIFF
--- a/SnippingTool/SnippingTool.csproj
+++ b/SnippingTool/SnippingTool.csproj
@@ -7,13 +7,18 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <!-- Hardcodet.Wpf.TaskbarNotification v1.0.5 targets .NET Framework but works fine on net10.0-windows -->
+    <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Hardcodet.Wpf.TaskbarNotification" Version="1.0.5" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.3" />
-    <PackageReference Include="System.Drawing.Common" Version="9.0.4" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated SnippingTool.csproj to add Serilog and related logging packages, enabling advanced logging features. Removed System.Drawing.Common package. Suppressed NU1701 warning for Hardcodet.Wpf.TaskbarNotification, which is compatible with net10.0-windows.