### PR TITLE
Add application icon to window and project settings

### DIFF
--- a/SnippingTool/MainWindow.xaml
+++ b/SnippingTool/MainWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:SnippingTool"
         mc:Ignorable="d"
-        Title="MainWindow" Height="450" Width="800">
+        Title="MainWindow" Icon="/Assets/icon.ico" Height="450" Width="800">
     <Grid>
 
     </Grid>

--- a/SnippingTool/SnippingTool.csproj
+++ b/SnippingTool/SnippingTool.csproj
@@ -7,6 +7,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <UseWPF>true</UseWPF>
     <UseWindowsForms>true</UseWindowsForms>
+    <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
     <!-- Hardcodet.Wpf.TaskbarNotification v1.0.5 targets .NET Framework but works fine on net10.0-windows -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>
   </PropertyGroup>
@@ -31,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Resource Include="Assets\icon.ico" />
+    <None Include="Assets\icon.ico" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Set MainWindow icon to Assets/icon.ico and configure SnippingTool.csproj to use it as the application icon. Changed icon.ico inclusion from Resource to None for correct icon handling.