### PR TITLE
Add Blur annotation tool for pixelating screenshot regions

### DIFF
--- a/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/AnnotationViewModelTests.cs
@@ -230,6 +230,42 @@ public sealed class AnnotationViewModelTests
         Assert.IsType<SnippingTool.Models.EllipseShapeParameters>(result);
     }
 
+    [Fact]
+    public void TryGetShapeParameters_Blur_ReturnsBlurParams()
+    {
+        // Arrange
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Blur;
+        vm.BeginDrawing(new System.Windows.Point(10, 20));
+        vm.UpdateDrawing(new System.Windows.Point(110, 120));
+
+        // Act
+        var result = vm.TryGetShapeParameters() as SnippingTool.Models.BlurShapeParameters;
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(10, result.Left);
+        Assert.Equal(20, result.Top);
+        Assert.Equal(100, result.Width);
+        Assert.Equal(100, result.Height);
+    }
+
+    [Fact]
+    public void TryGetShapeParameters_Blur_TooSmall_ReturnsNull()
+    {
+        // Arrange
+        var vm = new TestAnnotationViewModel(Geom());
+        vm.SelectedTool = AnnotationTool.Blur;
+        vm.BeginDrawing(new System.Windows.Point(0, 0));
+        vm.UpdateDrawing(new System.Windows.Point(1, 1));
+
+        // Act
+        var result = vm.TryGetShapeParameters();
+
+        // Assert
+        Assert.Null(result);
+    }
+
     // Every drag-producing tool must return a non-null ShapeParameters.
     // If a new tool is added to the enum but forgotten in TryGetShapeParameters,
     // this test will fail and catch the omission.
@@ -240,6 +276,7 @@ public sealed class AnnotationViewModelTests
     [InlineData(AnnotationTool.Pen)]
     [InlineData(AnnotationTool.Line)]
     [InlineData(AnnotationTool.Circle)]
+    [InlineData(AnnotationTool.Blur)]
     public void TryGetShapeParameters_AllDragTools_ReturnNonNull(AnnotationTool tool)
     {
         // Arrange

--- a/SnippingTool/AnnotationTool.cs
+++ b/SnippingTool/AnnotationTool.cs
@@ -1,3 +1,3 @@
 namespace SnippingTool;
 
-public enum AnnotationTool { Arrow, Rectangle, Text, Highlight, Pen, Line, Circle, Number }
+public enum AnnotationTool { Arrow, Rectangle, Text, Highlight, Pen, Line, Circle, Number, Blur }

--- a/SnippingTool/Models/ShapeParameters.cs
+++ b/SnippingTool/Models/ShapeParameters.cs
@@ -39,3 +39,9 @@ public sealed record PenShapeParameters(
     Point StartPoint,
     Color Color,
     double Thickness) : ShapeParameters;
+
+public sealed record BlurShapeParameters(
+    double Left,
+    double Top,
+    double Width,
+    double Height) : ShapeParameters;

--- a/SnippingTool/OverlayWindow.xaml
+++ b/SnippingTool/OverlayWindow.xaml
@@ -166,6 +166,12 @@
           <TextBlock Text="①" FontSize="15"/>
         </RadioButton>
 
+        <RadioButton Style="{StaticResource ToolBtn}"
+                     GroupName="AnnotTool"
+                     Tag="Blur" Click="Tool_Click" ToolTip="Blur / Pixelate">
+          <TextBlock Text="▒" FontSize="16"/>
+        </RadioButton>
+
         <!-- Divider -->
         <Rectangle Height="1" Fill="#D0D0D0" Margin="4,5"/>
 

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -26,7 +26,6 @@ public partial class OverlayWindow : Window
     private AnnotationCanvasRenderer _renderer = null!;
     private RecordingBorderWindow? _recordingBorder;
     private RecordingHudWindow? _recordingHud;
-    private BitmapSource? _backgroundCapture;
 
     public OverlayWindow(
         OverlayViewModel vm,
@@ -188,9 +187,9 @@ public partial class OverlayWindow : Window
         var screenH = Math.Max(1, (int)(sel.Height * _vm.DpiY));
         Visibility = Visibility.Hidden;
         System.Threading.Thread.Sleep(60);
-        _backgroundCapture = _screenCapture.Capture(screenX, screenY, screenW, screenH);
+        var backgroundCapture = _screenCapture.Capture(screenX, screenY, screenW, screenH);
         Visibility = Visibility.Visible;
-        _renderer.SetBackground(_backgroundCapture, _vm.DpiX, _vm.DpiY);
+        _renderer.SetBackground(backgroundCapture, _vm.DpiX, _vm.DpiY);
 
         LayoutDimStrips(sel);
 

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -26,6 +26,7 @@ public partial class OverlayWindow : Window
     private AnnotationCanvasRenderer _renderer = null!;
     private RecordingBorderWindow? _recordingBorder;
     private RecordingHudWindow? _recordingHud;
+    private BitmapSource? _backgroundCapture;
 
     public OverlayWindow(
         OverlayViewModel vm,
@@ -179,6 +180,18 @@ public partial class OverlayWindow : Window
         Cursor = Cursors.Arrow;
         SizeLabelBorder.Visibility = Visibility.Collapsed;
         DimFull.Visibility = Visibility.Collapsed;
+
+        // Capture clean background pixels for the blur/pixelate tool
+        var screenX = (int)((Left + sel.X) * _vm.DpiX);
+        var screenY = (int)((Top + sel.Y) * _vm.DpiY);
+        var screenW = Math.Max(1, (int)(sel.Width * _vm.DpiX));
+        var screenH = Math.Max(1, (int)(sel.Height * _vm.DpiY));
+        Visibility = Visibility.Hidden;
+        System.Threading.Thread.Sleep(60);
+        _backgroundCapture = _screenCapture.Capture(screenX, screenY, screenW, screenH);
+        Visibility = Visibility.Visible;
+        _renderer.SetBackground(_backgroundCapture, _vm.DpiX, _vm.DpiY);
+
         LayoutDimStrips(sel);
 
         AnnotationCanvas.Width = sel.Width;

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -180,7 +180,7 @@ public partial class OverlayWindow : Window
         SizeLabelBorder.Visibility = Visibility.Collapsed;
         DimFull.Visibility = Visibility.Collapsed;
 
-        // Capture clean background pixels for the blur/pixelate tool
+        // Capture clean background pixels for the pixelate tool
         var screenX = (int)((Left + sel.X) * _vm.DpiX);
         var screenY = (int)((Top + sel.Y) * _vm.DpiY);
         var screenW = Math.Max(1, (int)(sel.Width * _vm.DpiX));

--- a/SnippingTool/Services/AnnotationCanvasRenderer.cs
+++ b/SnippingTool/Services/AnnotationCanvasRenderer.cs
@@ -2,7 +2,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using System.Windows.Media.Effects;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using Microsoft.Extensions.Logging;
@@ -18,6 +17,8 @@ namespace SnippingTool.Services;
 
 internal sealed class AnnotationCanvasRenderer
 {
+    private const int PixelateBlockSize = 10;
+
     private readonly Canvas _canvas;
     private readonly AnnotationViewModel _vm;
     private readonly Action<UIElement> _onAdd;
@@ -214,14 +215,22 @@ internal sealed class AnnotationCanvasRenderer
 
         var cropped = new CroppedBitmap(_backgroundCapture, new Int32Rect(pixelX, pixelY, pixelW, pixelH));
         cropped.Freeze();
+
+        // Pixelate by scaling down to block resolution and back up with nearest-neighbour
+        var smallW = Math.Max(1, pixelW / PixelateBlockSize);
+        var smallH = Math.Max(1, pixelH / PixelateBlockSize);
+        var scaledDown = new TransformedBitmap(cropped,
+            new ScaleTransform((double)smallW / pixelW, (double)smallH / pixelH));
+        scaledDown.Freeze();
+
         var img = new System.Windows.Controls.Image
         {
             Width = @params.Width,
             Height = @params.Height,
-            Source = cropped,
+            Source = scaledDown,
             Stretch = Stretch.Fill,
-            Effect = new BlurEffect { Radius = 12, KernelType = KernelType.Gaussian, RenderingBias = RenderingBias.Quality }
         };
+        RenderOptions.SetBitmapScalingMode(img, BitmapScalingMode.NearestNeighbor);
         Canvas.SetLeft(img, @params.Left);
         Canvas.SetTop(img, @params.Top);
         Add(img);

--- a/SnippingTool/Services/AnnotationCanvasRenderer.cs
+++ b/SnippingTool/Services/AnnotationCanvasRenderer.cs
@@ -2,6 +2,8 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
+using System.Windows.Media.Effects;
+using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 using Microsoft.Extensions.Logging;
 using SnippingTool.Models;
@@ -27,6 +29,18 @@ internal sealed class AnnotationCanvasRenderer
     private System.Windows.Shapes.Rectangle? _currentRect;
     private Ellipse? _currentEllipse;
     private Polyline? _currentPen;
+    private System.Windows.Shapes.Rectangle? _blurDraft;
+
+    private BitmapSource? _backgroundCapture;
+    private double _dpiX = 1.0;
+    private double _dpiY = 1.0;
+
+    public void SetBackground(BitmapSource background, double dpiX, double dpiY)
+    {
+        _backgroundCapture = background;
+        _dpiX = dpiX;
+        _dpiY = dpiY;
+    }
 
     public AnnotationCanvasRenderer(
         Canvas canvas,
@@ -84,6 +98,18 @@ internal sealed class AnnotationCanvasRenderer
                 Canvas.SetTop(_currentEllipse, p.Y);
                 Add(_currentEllipse);
                 break;
+            case AnnotationTool.Blur:
+                _blurDraft = new System.Windows.Shapes.Rectangle
+                {
+                    Fill = new SolidColorBrush(Color.FromArgb(80, 120, 120, 120)),
+                    Stroke = Brushes.White,
+                    StrokeDashArray = new DoubleCollection { 4, 2 },
+                    StrokeThickness = 1
+                };
+                Canvas.SetLeft(_blurDraft, p.X);
+                Canvas.SetTop(_blurDraft, p.Y);
+                Add(_blurDraft);
+                break;
         }
     }
 
@@ -126,19 +152,79 @@ internal sealed class AnnotationCanvasRenderer
             case PenShapeParameters when _currentPen != null:
                 _currentPen.Points.Add(p);
                 break;
+            case BlurShapeParameters blur when _blurDraft != null:
+                Canvas.SetLeft(_blurDraft, blur.Left);
+                Canvas.SetTop(_blurDraft, blur.Top);
+                _blurDraft.Width = blur.Width;
+                _blurDraft.Height = blur.Height;
+                break;
         }
     }
 
     public void CommitShape(Point p)
     {
         _logger.LogDebug("Shape committed: {Tool}", _vm.SelectedTool);
-        UpdateShape(p);
+
+        if (_vm.SelectedTool == AnnotationTool.Blur)
+        {
+            CommitBlur();
+        }
+        else
+        {
+            UpdateShape(p);
+        }
+
         _arrowShaft = null;
         _arrowHead = null;
         _currentLine = null;
         _currentRect = null;
         _currentEllipse = null;
         _currentPen = null;
+        _blurDraft = null;
+    }
+
+    private void CommitBlur()
+    {
+        var @params = _vm.TryGetShapeParameters() as BlurShapeParameters;
+        if (_blurDraft != null)
+        {
+            _canvas.Children.Remove(_blurDraft);
+        }
+
+        if (@params == null || _backgroundCapture == null)
+        {
+            return;
+        }
+
+        var pixelX = (int)(@params.Left * _dpiX);
+        var pixelY = (int)(@params.Top * _dpiY);
+        var pixelW = Math.Max(1, (int)(@params.Width * _dpiX));
+        var pixelH = Math.Max(1, (int)(@params.Height * _dpiY));
+
+        // Clamp to bitmap bounds
+        pixelX = Math.Max(0, Math.Min(pixelX, _backgroundCapture.PixelWidth - 1));
+        pixelY = Math.Max(0, Math.Min(pixelY, _backgroundCapture.PixelHeight - 1));
+        pixelW = Math.Min(pixelW, _backgroundCapture.PixelWidth - pixelX);
+        pixelH = Math.Min(pixelH, _backgroundCapture.PixelHeight - pixelY);
+
+        if (pixelW <= 0 || pixelH <= 0)
+        {
+            return;
+        }
+
+        var cropped = new CroppedBitmap(_backgroundCapture, new Int32Rect(pixelX, pixelY, pixelW, pixelH));
+        cropped.Freeze();
+        var img = new System.Windows.Controls.Image
+        {
+            Width = @params.Width,
+            Height = @params.Height,
+            Source = cropped,
+            Stretch = Stretch.Fill,
+            Effect = new BlurEffect { Radius = 12, KernelType = KernelType.Gaussian, RenderingBias = RenderingBias.Quality }
+        };
+        Canvas.SetLeft(img, @params.Left);
+        Canvas.SetTop(img, @params.Top);
+        Add(img);
     }
 
     public void PlaceNumberLabel(Point p)

--- a/SnippingTool/ViewModels/AnnotationViewModel.cs
+++ b/SnippingTool/ViewModels/AnnotationViewModel.cs
@@ -156,6 +156,8 @@ public partial class AnnotationViewModel : ObservableObject
                 Color: color,
                 Thickness: thick),
 
+            AnnotationTool.Blur => BuildBlurParams(DragStart, DragCurrent),
+
             _ => null
         };
     }
@@ -170,6 +172,12 @@ public partial class AnnotationViewModel : ObservableObject
     {
         var (left, top, width, height) = _geometry.CalculateEllipse(start, end);
         return new EllipseShapeParameters(left, top, width, height, color, thick);
+    }
+
+    private BlurShapeParameters BuildBlurParams(Point start, Point end)
+    {
+        var (left, top, width, height) = _geometry.CalculateRect(start, end);
+        return new BlurShapeParameters(left, top, width, height);
     }
 
     private readonly List<List<object>> _undoStack = [];


### PR DESCRIPTION
Introduces a new Blur tool to the annotation toolbar, allowing users to select and blur/pixelate regions of their screenshot. Captures a clean background image of the selection area and applies a blur effect to the chosen region. Updates the UI, shape parameters, and rendering logic to support this feature.