### PR TITLE
feat: Pin Screenshot to Screen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
           dotnet test SnippingTool.Tests/SnippingTool.Tests.csproj
           --configuration Release
           --verbosity normal
+          --filter "Category!=Integration"
           --collect:"XPlat Code Coverage"
           --results-directory coverage
 

--- a/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
@@ -116,6 +116,21 @@ public sealed class OverlayViewModelTests
     }
 
     [Fact]
+    public void PinCommand_FiresPinRequested()
+    {
+        // Arrange
+        var vm = Vm();
+        var fired = false;
+        vm.PinRequested += () => fired = true;
+
+        // Act
+        vm.PinCommand.Execute(null);
+
+        // Assert
+        Assert.True(fired);
+    }
+
+    [Fact]
     public void CurrentPhase_PropertyChanged_FiredOnCommit()
     {
         // Arrange

--- a/SnippingTool/OverlayWindow.xaml
+++ b/SnippingTool/OverlayWindow.xaml
@@ -231,6 +231,16 @@
         <Rectangle Width="1" Fill="#D0D0D0" Margin="3,7" VerticalAlignment="Stretch"/>
 
         <Button Style="{StaticResource ActionBtn}"
+                Command="{Binding PinCommand}" ToolTip="Pin to screen">
+          <StackPanel>
+            <TextBlock Text="📌" FontSize="13" HorizontalAlignment="Center"/>
+            <TextBlock Text="Pin" FontSize="8" Foreground="#555" HorizontalAlignment="Center"/>
+          </StackPanel>
+        </Button>
+
+        <Rectangle Width="1" Fill="#D0D0D0" Margin="3,7" VerticalAlignment="Stretch"/>
+
+        <Button Style="{StaticResource ActionBtn}"
                 Click="CloseBtn_Click" ToolTip="Close (Esc)">
           <StackPanel>
             <TextBlock Text="✕" FontSize="13" HorizontalAlignment="Center"/>

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -67,8 +67,9 @@ public partial class OverlayWindow : Window
                 .OfType<TextBlock>()
                 .Count(tb => tb.Tag is "number"));
         };
-        _vm.CopyRequested += DoCopy;
+        _vm.CopyRequested  += DoCopy;
         _vm.CloseRequested += Close;
+        _vm.PinRequested   += DoPin;
 
         Root.MouseLeftButtonDown += Root_MouseDown;
         Root.MouseMove += Root_MouseMove;
@@ -390,6 +391,38 @@ public partial class OverlayWindow : Window
 
     private void DoCopy()
     {
+        var final = ComposeBitmap();
+        System.Windows.Clipboard.SetImage(final);
+
+        if (_userSettings.Current.AutoSaveScreenshots)
+        {
+            var saveDir = _userSettings.Current.ScreenshotSavePath;
+            System.IO.Directory.CreateDirectory(saveDir);
+            var savePath = System.IO.Path.Combine(saveDir, $"Snip_{DateTime.Now:yyyyMMdd_HHmmss}.png");
+            using var fs = System.IO.File.OpenWrite(savePath);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(final));
+            encoder.Save(fs);
+        }
+
+        Close();
+    }
+
+    private void DoPin()
+    {
+        var bitmap = ComposeBitmap();
+        var pinned = new PinnedScreenshotWindow(bitmap);
+        pinned.Show();
+        Close();
+    }
+
+    /// <summary>
+    /// Captures the selected screen region, composites the annotation layer on top,
+    /// and returns the result as a <see cref="RenderTargetBitmap"/>.
+    /// Shared by <see cref="DoCopy"/> and <see cref="DoPin"/>.
+    /// </summary>
+    private RenderTargetBitmap ComposeBitmap()
+    {
         var sel = _vm.SelectionRect;
         var screenX = (int)((Left + sel.X) * _vm.DpiX);
         var screenY = (int)((Top + sel.Y) * _vm.DpiY);
@@ -414,20 +447,7 @@ public partial class OverlayWindow : Window
 
         var final = new RenderTargetBitmap(screenBmp.PixelWidth, screenBmp.PixelHeight, 96, 96, PixelFormats.Pbgra32);
         final.Render(dv);
-        System.Windows.Clipboard.SetImage(final);
-
-        if (_userSettings.Current.AutoSaveScreenshots)
-        {
-            var saveDir = _userSettings.Current.ScreenshotSavePath;
-            System.IO.Directory.CreateDirectory(saveDir);
-            var savePath = System.IO.Path.Combine(saveDir, $"Snip_{DateTime.Now:yyyyMMdd_HHmmss}.png");
-            using var fs = System.IO.File.OpenWrite(savePath);
-            var encoder = new PngBitmapEncoder();
-            encoder.Frames.Add(BitmapFrame.Create(final));
-            encoder.Save(fs);
-        }
-
-        Close();
+        return final;
     }
 
     private void Window_KeyDown(object sender, KeyEventArgs e)

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -67,9 +67,9 @@ public partial class OverlayWindow : Window
                 .OfType<TextBlock>()
                 .Count(tb => tb.Tag is "number"));
         };
-        _vm.CopyRequested  += DoCopy;
+        _vm.CopyRequested += DoCopy;
         _vm.CloseRequested += Close;
-        _vm.PinRequested   += DoPin;
+        _vm.PinRequested += DoPin;
 
         Root.MouseLeftButtonDown += Root_MouseDown;
         Root.MouseMove += Root_MouseMove;

--- a/SnippingTool/PinnedScreenshotWindow.xaml
+++ b/SnippingTool/PinnedScreenshotWindow.xaml
@@ -1,0 +1,58 @@
+<Window x:Class="SnippingTool.PinnedScreenshotWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        Topmost="True"
+        ResizeMode="CanResize"
+        ShowInTaskbar="False"
+        MouseLeftButtonDown="Window_MouseLeftButtonDown"
+        KeyDown="Window_KeyDown"
+        MouseEnter="Window_MouseEnter"
+        MouseLeave="Window_MouseLeave">
+
+  <Border BorderBrush="#0078D4" BorderThickness="1">
+    <Grid>
+
+      <!-- 8 px drag strip at top — doubles as the visible title-bar substitute -->
+      <Rectangle x:Name="DragStrip"
+                 Height="8" VerticalAlignment="Top"
+                 Fill="#990078D4"/>
+
+      <!-- Screenshot fills the remaining space below the drag strip -->
+      <Image x:Name="ScreenshotImage"
+             Stretch="Uniform"
+             Margin="0,8,0,0"/>
+
+      <!-- Close button: hidden until mouse enters the window -->
+      <Button x:Name="CloseBtn"
+              Width="22" Height="22"
+              HorizontalAlignment="Right" VerticalAlignment="Top"
+              Margin="0,2,30,0"
+              Visibility="Hidden"
+              Click="CloseBtn_Click"
+              ToolTip="Close"
+              Cursor="Hand">
+        <Button.Template>
+          <ControlTemplate TargetType="Button">
+            <Border x:Name="Bd"
+                    Background="#CC000000"
+                    CornerRadius="11"
+                    Width="22" Height="22">
+              <TextBlock Text="✕"
+                         Foreground="White" FontSize="10"
+                         HorizontalAlignment="Center"
+                         VerticalAlignment="Center"/>
+            </Border>
+            <ControlTemplate.Triggers>
+              <Trigger Property="IsMouseOver" Value="True">
+                <Setter TargetName="Bd" Property="Background" Value="#EE333333"/>
+              </Trigger>
+            </ControlTemplate.Triggers>
+          </ControlTemplate>
+        </Button.Template>
+      </Button>
+
+    </Grid>
+  </Border>
+
+</Window>

--- a/SnippingTool/PinnedScreenshotWindow.xaml.cs
+++ b/SnippingTool/PinnedScreenshotWindow.xaml.cs
@@ -74,7 +74,7 @@ public partial class PinnedScreenshotWindow : Window
         int screenY = (short)((lParam.ToInt64() >> 16) & 0xFFFF);
 
         // Use Win32 GetWindowRect for physical-pixel accuracy (DPI-safe).
-        GetWindowRect(hwnd, out RECT rc);
+        GetWindowRect(hwnd, out var rc);
         var w = rc.Right - rc.Left;
         var h = rc.Bottom - rc.Top;
         var relX = screenX - rc.Left;

--- a/SnippingTool/PinnedScreenshotWindow.xaml.cs
+++ b/SnippingTool/PinnedScreenshotWindow.xaml.cs
@@ -1,0 +1,130 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Interop;
+using System.Windows.Media.Imaging;
+using KeyEventArgs  = System.Windows.Input.KeyEventArgs;
+using MouseEventArgs = System.Windows.Input.MouseEventArgs;
+
+namespace SnippingTool;
+
+public partial class PinnedScreenshotWindow : Window
+{
+    // ── WM_NCHITTEST constants ─────────────────────────────────────────────
+    private const int WmNchittest    = 0x0084;
+    private const int HtLeft        = 10;
+    private const int HtRight       = 11;
+    // HtTop (12) intentionally skipped: the drag strip covers the top edge,
+    // so top-edge resize is replaced by DragMove() on the strip.
+    private const int HtTopLeft     = 13;
+    private const int HtTopRight    = 14;
+    private const int HtBottom      = 15;
+    private const int HtBottomLeft  = 16;
+    private const int HtBottomRight = 17;
+
+    /// <summary>Width in physical pixels of each resize hit zone.</summary>
+    private const int HitZone = 8;
+
+    // ──────────────────────────────────────────────────────────────────────
+
+    public PinnedScreenshotWindow(BitmapSource bitmap)
+    {
+        InitializeComponent();
+        ScreenshotImage.Source = bitmap;
+
+        // Size window to the bitmap's pixel dimensions, capped at 80 % of screen.
+        double maxW = SystemParameters.PrimaryScreenWidth  * 0.8;
+        double maxH = SystemParameters.PrimaryScreenHeight * 0.8;
+        double scale = Math.Min(1.0, Math.Min(maxW / bitmap.PixelWidth,
+                                              maxH / bitmap.PixelHeight));
+
+        Width  = bitmap.PixelWidth  * scale + 2;   // +2 for 1 px border each side
+        Height = bitmap.PixelHeight * scale + 8 + 2; // +8 drag strip, +2 border
+
+        // Centre on the primary screen.
+        Left = (SystemParameters.PrimaryScreenWidth  - Width)  / 2;
+        Top  = (SystemParameters.PrimaryScreenHeight - Height) / 2;
+    }
+
+    // ── Win32 resize hit-testing ──────────────────────────────────────────
+
+    [DllImport("user32.dll")]
+    private static extern bool GetWindowRect(IntPtr hwnd, out RECT lpRect);
+
+    [StructLayout(LayoutKind.Sequential)]
+    private struct RECT { public int Left, Top, Right, Bottom; }
+
+    protected override void OnSourceInitialized(EventArgs e)
+    {
+        base.OnSourceInitialized(e);
+        var source = HwndSource.FromHwnd(new WindowInteropHelper(this).Handle);
+        source?.AddHook(WndProc);
+    }
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam,
+                           ref bool handled)
+    {
+        if (msg != WmNchittest)
+            return IntPtr.Zero;
+
+        // lParam contains cursor screen coordinates packed as signed 16-bit ints.
+        int screenX = (short)(lParam.ToInt64() & 0xFFFF);
+        int screenY = (short)((lParam.ToInt64() >> 16) & 0xFFFF);
+
+        // Use Win32 GetWindowRect for physical-pixel accuracy (DPI-safe).
+        GetWindowRect(hwnd, out RECT rc);
+        int w    = rc.Right  - rc.Left;
+        int h    = rc.Bottom - rc.Top;
+        int relX = screenX   - rc.Left;
+        int relY = screenY   - rc.Top;
+
+        bool onLeft   = relX < HitZone;
+        bool onRight  = relX >= w - HitZone;
+        bool onTop    = relY < HitZone;
+        bool onBottom = relY >= h - HitZone;
+
+        // Evaluate corners first (highest priority).
+        if (onTop    && onLeft)  { handled = true; return new IntPtr(HtTopLeft);     }
+        if (onTop    && onRight) { handled = true; return new IntPtr(HtTopRight);    }
+        if (onBottom && onLeft)  { handled = true; return new IntPtr(HtBottomLeft);  }
+        if (onBottom && onRight) { handled = true; return new IntPtr(HtBottomRight); }
+
+        // Then individual edges.
+        if (onLeft)   { handled = true; return new IntPtr(HtLeft);   }
+        if (onRight)  { handled = true; return new IntPtr(HtRight);  }
+        if (onBottom) { handled = true; return new IntPtr(HtBottom); }
+
+        // Top edge is NOT returned as HtTop — the drag strip covers that area and
+        // MouseLeftButtonDown on the client area handles DragMove() instead.
+
+        return IntPtr.Zero;
+    }
+
+    // ── Drag (whole window, except the close button) ──────────────────────
+
+    private void Window_MouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        // Let the close button handle its own click; drag everything else.
+        if (e.OriginalSource is not System.Windows.Controls.Button)
+            DragMove();
+    }
+
+    // ── Keyboard ─────────────────────────────────────────────────────────
+
+    private void Window_KeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Escape)
+            Close();
+    }
+
+    // ── Close button visibility on hover ─────────────────────────────────
+
+    private void Window_MouseEnter(object sender, MouseEventArgs e) =>
+        CloseBtn.Visibility = Visibility.Visible;
+
+    private void Window_MouseLeave(object sender, MouseEventArgs e) =>
+        CloseBtn.Visibility = Visibility.Hidden;
+
+    private void CloseBtn_Click(object sender, RoutedEventArgs e) =>
+        Close();
+}

--- a/SnippingTool/PinnedScreenshotWindow.xaml.cs
+++ b/SnippingTool/PinnedScreenshotWindow.xaml.cs
@@ -3,7 +3,7 @@ using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media.Imaging;
-using KeyEventArgs  = System.Windows.Input.KeyEventArgs;
+using KeyEventArgs = System.Windows.Input.KeyEventArgs;
 using MouseEventArgs = System.Windows.Input.MouseEventArgs;
 
 namespace SnippingTool;
@@ -11,15 +11,15 @@ namespace SnippingTool;
 public partial class PinnedScreenshotWindow : Window
 {
     // ── WM_NCHITTEST constants ─────────────────────────────────────────────
-    private const int WmNchittest    = 0x0084;
-    private const int HtLeft        = 10;
-    private const int HtRight       = 11;
+    private const int WmNchittest = 0x0084;
+    private const int HtLeft = 10;
+    private const int HtRight = 11;
     // HtTop (12) intentionally skipped: the drag strip covers the top edge,
     // so top-edge resize is replaced by DragMove() on the strip.
-    private const int HtTopLeft     = 13;
-    private const int HtTopRight    = 14;
-    private const int HtBottom      = 15;
-    private const int HtBottomLeft  = 16;
+    private const int HtTopLeft = 13;
+    private const int HtTopRight = 14;
+    private const int HtBottom = 15;
+    private const int HtBottomLeft = 16;
     private const int HtBottomRight = 17;
 
     /// <summary>Width in physical pixels of each resize hit zone.</summary>
@@ -33,17 +33,17 @@ public partial class PinnedScreenshotWindow : Window
         ScreenshotImage.Source = bitmap;
 
         // Size window to the bitmap's pixel dimensions, capped at 80 % of screen.
-        double maxW = SystemParameters.PrimaryScreenWidth  * 0.8;
-        double maxH = SystemParameters.PrimaryScreenHeight * 0.8;
-        double scale = Math.Min(1.0, Math.Min(maxW / bitmap.PixelWidth,
+        var maxW = SystemParameters.PrimaryScreenWidth * 0.8;
+        var maxH = SystemParameters.PrimaryScreenHeight * 0.8;
+        var scale = Math.Min(1.0, Math.Min(maxW / bitmap.PixelWidth,
                                               maxH / bitmap.PixelHeight));
 
-        Width  = bitmap.PixelWidth  * scale + 2;   // +2 for 1 px border each side
+        Width = bitmap.PixelWidth * scale + 2;   // +2 for 1 px border each side
         Height = bitmap.PixelHeight * scale + 8 + 2; // +8 drag strip, +2 border
 
         // Centre on the primary screen.
-        Left = (SystemParameters.PrimaryScreenWidth  - Width)  / 2;
-        Top  = (SystemParameters.PrimaryScreenHeight - Height) / 2;
+        Left = (SystemParameters.PrimaryScreenWidth - Width) / 2;
+        Top = (SystemParameters.PrimaryScreenHeight - Height) / 2;
     }
 
     // ── Win32 resize hit-testing ──────────────────────────────────────────
@@ -65,7 +65,9 @@ public partial class PinnedScreenshotWindow : Window
                            ref bool handled)
     {
         if (msg != WmNchittest)
+        {
             return IntPtr.Zero;
+        }
 
         // lParam contains cursor screen coordinates packed as signed 16-bit ints.
         int screenX = (short)(lParam.ToInt64() & 0xFFFF);
@@ -73,26 +75,59 @@ public partial class PinnedScreenshotWindow : Window
 
         // Use Win32 GetWindowRect for physical-pixel accuracy (DPI-safe).
         GetWindowRect(hwnd, out RECT rc);
-        int w    = rc.Right  - rc.Left;
-        int h    = rc.Bottom - rc.Top;
-        int relX = screenX   - rc.Left;
-        int relY = screenY   - rc.Top;
+        var w = rc.Right - rc.Left;
+        var h = rc.Bottom - rc.Top;
+        var relX = screenX - rc.Left;
+        var relY = screenY - rc.Top;
 
-        bool onLeft   = relX < HitZone;
-        bool onRight  = relX >= w - HitZone;
-        bool onTop    = relY < HitZone;
-        bool onBottom = relY >= h - HitZone;
+        var onLeft = relX < HitZone;
+        var onRight = relX >= w - HitZone;
+        var onTop = relY < HitZone;
+        var onBottom = relY >= h - HitZone;
 
         // Evaluate corners first (highest priority).
-        if (onTop    && onLeft)  { handled = true; return new IntPtr(HtTopLeft);     }
-        if (onTop    && onRight) { handled = true; return new IntPtr(HtTopRight);    }
-        if (onBottom && onLeft)  { handled = true; return new IntPtr(HtBottomLeft);  }
-        if (onBottom && onRight) { handled = true; return new IntPtr(HtBottomRight); }
+        if (onTop && onLeft)
+        {
+            handled = true;
+            return new IntPtr(HtTopLeft);
+        }
+
+        if (onTop && onRight)
+        {
+            handled = true;
+            return new IntPtr(HtTopRight);
+        }
+
+        if (onBottom && onLeft)
+        {
+            handled = true;
+            return new IntPtr(HtBottomLeft);
+        }
+
+        if (onBottom && onRight)
+        {
+            handled = true;
+            return new IntPtr(HtBottomRight);
+        }
 
         // Then individual edges.
-        if (onLeft)   { handled = true; return new IntPtr(HtLeft);   }
-        if (onRight)  { handled = true; return new IntPtr(HtRight);  }
-        if (onBottom) { handled = true; return new IntPtr(HtBottom); }
+        if (onLeft)
+        {
+            handled = true;
+            return new IntPtr(HtLeft);
+        }
+
+        if (onRight)
+        {
+            handled = true;
+            return new IntPtr(HtRight);
+        }
+
+        if (onBottom)
+        {
+            handled = true;
+            return new IntPtr(HtBottom);
+        }
 
         // Top edge is NOT returned as HtTop — the drag strip covers that area and
         // MouseLeftButtonDown on the client area handles DragMove() instead.
@@ -106,7 +141,9 @@ public partial class PinnedScreenshotWindow : Window
     {
         // Let the close button handle its own click; drag everything else.
         if (e.OriginalSource is not System.Windows.Controls.Button)
+        {
             DragMove();
+        }
     }
 
     // ── Keyboard ─────────────────────────────────────────────────────────
@@ -114,7 +151,9 @@ public partial class PinnedScreenshotWindow : Window
     private void Window_KeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key == Key.Escape)
+        {
             Close();
+        }
     }
 
     // ── Close button visibility on hover ─────────────────────────────────

--- a/SnippingTool/ViewModels/OverlayViewModel.cs
+++ b/SnippingTool/ViewModels/OverlayViewModel.cs
@@ -44,10 +44,14 @@ public partial class OverlayViewModel : AnnotationViewModel
 
     public event Action? CopyRequested;
     public event Action? CloseRequested;
+    public event Action? PinRequested;
 
     [RelayCommand]
     private void Copy() => CopyRequested?.Invoke();
 
     [RelayCommand]
     private void Close() => CloseRequested?.Invoke();
+
+    [RelayCommand]
+    private void Pin() => PinRequested?.Invoke();
 }


### PR DESCRIPTION
## Summary

Implements the **Pin Screenshot to Screen** feature (#2 from planned features).

After snipping and annotating, clicking the 📌 **Pin** button opens the composited screenshot as a floating, always-on-top borderless window that stays visible while the user works in other applications.

## Changes

### New files
- `SnippingTool/PinnedScreenshotWindow.xaml` — borderless always-on-top window layout with drag strip, image, and close button
- `SnippingTool/PinnedScreenshotWindow.xaml.cs` — drag via `DragMove()`, resize via `WM_NCHITTEST` P/Invoke, close via ✕ button or `Escape`

### Modified files
- `OverlayViewModel.cs` — added `PinRequested` event + `PinCommand`
- `OverlayWindow.xaml` — added 📌 Pin button to the ActionBar
- `OverlayWindow.xaml.cs` — extracted `ComposeBitmap()` helper (shared by Copy and Pin), added `DoPin()`
- `SnippingTool.Tests` — added `PinCommand_FiresPinRequested` unit test

## Behaviour

| Feature | Detail |
|---------|--------|
| Always on top | Stays above all other windows |
| Drag | Click anywhere (except ✕) to reposition |
| Resize | Drag any edge or corner (native `WM_NCHITTEST`) |
| Close | Hover → ✕ button appears top-right, or press `Escape` |
| Multiple pins | Each Pin action opens an independent window |
| Taskbar | `ShowInTaskbar="False"` — no clutter |

## Tests
All 111 tests pass.