### PR TITLE
Add frozen screen snapshot as overlay background

### DIFF
--- a/SnippingTool/OverlayWindow.xaml
+++ b/SnippingTool/OverlayWindow.xaml
@@ -77,6 +77,9 @@
   <!-- Root canvas — near-transparent so WPF hit-tests it (fully transparent = no hit-test) -->
   <Canvas x:Name="Root" Background="#01000000">
 
+    <!-- Frozen screen snapshot — painted first so the live desktop is never visible -->
+    <Image x:Name="ScreenSnapshot" Stretch="Fill"/>
+
     <!-- ── Phase 1: single full-screen dim ── -->
     <Rectangle x:Name="DimFull" Fill="#80000000"/>
 

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -112,6 +112,8 @@ public partial class OverlayWindow : Window
 
         DimFull.Width = Width;
         DimFull.Height = Height;
+        ScreenSnapshot.Width = Width;
+        ScreenSnapshot.Height = Height;
 
         var src = PresentationSource.FromVisual(this);
         if (src?.CompositionTarget != null)
@@ -125,6 +127,7 @@ public partial class OverlayWindow : Window
         _screenSnapshot = _screenCapture.Capture(
             (int)(Left * _vm.DpiX), (int)(Top * _vm.DpiY),
             (int)(Width * _vm.DpiX), (int)(Height * _vm.DpiY));
+        ScreenSnapshot.Source = _screenSnapshot;
         Visibility = Visibility.Visible;
     }
 


### PR DESCRIPTION
Introduce a ScreenSnapshot Image to the overlay window, displaying a captured screen image as the background. This ensures the live desktop is never visible during overlay operations. The snapshot's size is set to match the overlay, and its source is updated after capture.