### PR TITLE
Add "Open existing image" feature for annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949
 - **Annotation tools** — Arrow, line, rectangle, circle, pen, highlighter, text, numbered steps, blur
 - **Blur tool** — Drag over sensitive content (faces, emails, passwords) to apply a Gaussian blur before sharing
 - **OCR — Copy Text** — Draw a lasso around text in the screenshot to extract it via OCR and copy to clipboard (uses Windows.Media.Ocr, no external dependencies)
+- **Open existing image** — Load a PNG, JPG/JPEG, or BMP from the tray menu and annotate it without taking a new screenshot
 - **Pin screenshot** — Pin the captured screenshot as a floating, always-on-top, resizable window for quick reference while you work
 - **Undo / redo** — Full undo/redo stack during annotation
 - **Copy & auto-save** — Copy to clipboard; optional auto-save to a configurable folder

--- a/SnippingTool.Tests/OverlayWindowLayoutTests.cs
+++ b/SnippingTool.Tests/OverlayWindowLayoutTests.cs
@@ -1,0 +1,37 @@
+using System.Windows;
+using Xunit;
+
+namespace SnippingTool.Tests;
+
+public sealed class OverlayWindowLayoutTests
+{
+    [Fact]
+    public void CalculateOpenedImageDisplayRect_CentersImageInsideSingleMonitorTargetArea()
+    {
+        var targetArea = new Rect(1920, 0, 1920, 1400);
+
+        var result = OverlayWindow.CalculateOpenedImageDisplayRect(1600, 900, targetArea, 140);
+
+        Assert.True(result.Left >= targetArea.Left);
+        Assert.True(result.Right <= targetArea.Right);
+        Assert.True(result.Top >= targetArea.Top);
+        Assert.True(result.Bottom <= targetArea.Bottom);
+        Assert.Equal(1600, result.Width);
+        Assert.Equal(900, result.Height);
+    }
+
+    [Fact]
+    public void CalculateOpenedImageDisplayRect_ScalesDownLargeImageWithoutCrossingMonitorBounds()
+    {
+        var targetArea = new Rect(1920, 0, 1920, 1040);
+
+        var result = OverlayWindow.CalculateOpenedImageDisplayRect(4000, 3000, targetArea, 140);
+
+        Assert.True(result.Left >= targetArea.Left);
+        Assert.True(result.Right <= targetArea.Right);
+        Assert.True(result.Top >= targetArea.Top);
+        Assert.True(result.Bottom <= targetArea.Bottom);
+        Assert.True(result.Width <= (targetArea.Width - 280) + 0.01);
+        Assert.True(result.Height <= (targetArea.Height - 280) + 0.01);
+    }
+}

--- a/SnippingTool.Tests/Services/ImageFileServiceTests.cs
+++ b/SnippingTool.Tests/Services/ImageFileServiceTests.cs
@@ -1,0 +1,128 @@
+using System.IO;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using SnippingTool.Services;
+using Xunit;
+
+namespace SnippingTool.Tests.Services;
+
+public sealed class ImageFileServiceTests : IDisposable
+{
+    private readonly string _tempDirectory = Path.Combine(
+        Path.GetTempPath(),
+        "SnippingTool.Tests",
+        Guid.NewGuid().ToString("N"));
+
+    [Theory]
+    [InlineData(".png")]
+    [InlineData(".jpg")]
+    [InlineData(".bmp")]
+    public void LoadForAnnotation_LoadsSupportedFormats(string extension)
+    {
+        var path = CreateImageFile(extension);
+        var sut = new ImageFileService();
+
+        var result = sut.LoadForAnnotation(path);
+
+        Assert.Equal(2, result.PixelWidth);
+        Assert.Equal(2, result.PixelHeight);
+        Assert.True(result.IsFrozen);
+    }
+
+    [Fact]
+    public void LoadForAnnotation_WhenExtensionIsUnsupported_ThrowsNotSupportedException()
+    {
+        var path = Path.Combine(_tempDirectory, "image.gif");
+        Directory.CreateDirectory(_tempDirectory);
+        File.WriteAllText(path, "not-an-image");
+        var sut = new ImageFileService();
+
+        var exception = Assert.Throws<NotSupportedException>(() => sut.LoadForAnnotation(path));
+
+        Assert.Contains("Unsupported image format", exception.Message);
+    }
+
+    [Fact]
+    public void LoadForAnnotation_WhenFileIsMissing_ThrowsFileNotFoundException()
+    {
+        var path = Path.Combine(_tempDirectory, "missing.png");
+        var sut = new ImageFileService();
+
+        var exception = Assert.Throws<FileNotFoundException>(() => sut.LoadForAnnotation(path));
+
+        Assert.Equal(path, exception.FileName);
+    }
+
+    [Fact]
+    public void LoadForAnnotation_WhenFileIsCorrupt_ThrowsInvalidDataException()
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var path = Path.Combine(_tempDirectory, "corrupt.png");
+        File.WriteAllText(path, "not-a-real-png");
+        var sut = new ImageFileService();
+
+        var exception = Assert.Throws<InvalidDataException>(() => sut.LoadForAnnotation(path));
+
+        Assert.Contains("could not be opened", exception.Message);
+    }
+
+    [Fact]
+    public void LoadForAnnotation_LoadsBitmapIntoMemoryAndReleasesSourceFile()
+    {
+        var path = CreateImageFile(".png");
+        var sut = new ImageFileService();
+
+        var result = sut.LoadForAnnotation(path);
+        File.Delete(path);
+
+        Assert.False(File.Exists(path));
+        Assert.Equal(2, result.PixelWidth);
+        Assert.Equal(2, result.PixelHeight);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDirectory))
+        {
+            Directory.Delete(_tempDirectory, recursive: true);
+        }
+    }
+
+    private string CreateImageFile(string extension)
+    {
+        Directory.CreateDirectory(_tempDirectory);
+        var path = Path.Combine(_tempDirectory, $"image{extension}");
+
+        var bitmap = BitmapSource.Create(
+            2,
+            2,
+            96,
+            96,
+            PixelFormats.Bgra32,
+            null,
+            new byte[]
+            {
+                0, 0, 255, 255,
+                0, 255, 0, 255,
+                255, 0, 0, 255,
+                255, 255, 255, 255
+            },
+            8);
+
+        var encoder = CreateEncoder(extension);
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+
+        using var stream = File.Create(path);
+        encoder.Save(stream);
+
+        return path;
+    }
+
+    private static BitmapEncoder CreateEncoder(string extension) => extension switch
+    {
+        ".png" => new PngBitmapEncoder(),
+        ".jpg" => new JpegBitmapEncoder(),
+        ".bmp" => new BmpBitmapEncoder(),
+        _ => throw new ArgumentOutOfRangeException(nameof(extension), extension, null)
+    };
+}

--- a/SnippingTool.Tests/Services/OpenedImageBitmapCaptureTests.cs
+++ b/SnippingTool.Tests/Services/OpenedImageBitmapCaptureTests.cs
@@ -1,0 +1,141 @@
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+using System.Runtime.ExceptionServices;
+using SnippingTool.Services;
+using Xunit;
+
+namespace SnippingTool.Tests.Services;
+
+public sealed class OpenedImageBitmapCaptureTests
+{
+    [Fact]
+    public void ComposeBitmap_ReturnsBitmapWithSourcePixelDimensions()
+    {
+        RunInSta(() =>
+        {
+            var sourceBitmap = CreateSolidBitmap(200, 100, Colors.Blue);
+            var canvas = new Canvas
+            {
+                Width = 100,
+                Height = 50
+            };
+            var sut = new OpenedImageBitmapCapture(sourceBitmap, canvas);
+
+            var result = sut.ComposeBitmap();
+
+            Assert.Equal(200, result.PixelWidth);
+            Assert.Equal(100, result.PixelHeight);
+        });
+    }
+
+    [Fact]
+    public void ComposeBitmap_CompositesAnnotationCanvasOntoSourceBitmap()
+    {
+        RunInSta(() =>
+        {
+            var sourceBitmap = CreateSolidBitmap(200, 100, Colors.Blue);
+            var canvas = new Canvas
+            {
+                Width = 100,
+                Height = 50
+            };
+            var annotation = new Rectangle
+            {
+                Width = 20,
+                Height = 10,
+                Fill = Brushes.Red
+            };
+            Canvas.SetLeft(annotation, 25);
+            Canvas.SetTop(annotation, 10);
+            canvas.Children.Add(annotation);
+            var sut = new OpenedImageBitmapCapture(sourceBitmap, canvas);
+
+            var result = sut.ComposeBitmap();
+            var pixel = ReadPixel(result, 60, 30);
+
+            Assert.Equal(255, pixel.A);
+            Assert.True(pixel.R > 200);
+            Assert.True(pixel.G < 50);
+            Assert.True(pixel.B < 50);
+        });
+    }
+
+    [Fact]
+    public void ComposeBitmap_ReturnsFrozenBitmap()
+    {
+        RunInSta(() =>
+        {
+            var sourceBitmap = CreateSolidBitmap(50, 30, Colors.Green);
+            var canvas = new Canvas
+            {
+                Width = 25,
+                Height = 15
+            };
+            var sut = new OpenedImageBitmapCapture(sourceBitmap, canvas);
+
+            var result = sut.ComposeBitmap();
+
+            Assert.True(result.IsFrozen);
+        });
+    }
+
+    private static void RunInSta(Action action)
+    {
+        ExceptionDispatchInfo? capturedException = null;
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                action();
+            }
+            catch (Exception ex)
+            {
+                capturedException = ExceptionDispatchInfo.Capture(ex);
+            }
+        });
+
+        thread.SetApartmentState(ApartmentState.STA);
+        thread.Start();
+        thread.Join();
+
+        capturedException?.Throw();
+    }
+
+    private static BitmapSource CreateSolidBitmap(int width, int height, Color color)
+    {
+        var pixels = new byte[width * height * 4];
+
+        for (var i = 0; i < pixels.Length; i += 4)
+        {
+            pixels[i] = color.B;
+            pixels[i + 1] = color.G;
+            pixels[i + 2] = color.R;
+            pixels[i + 3] = color.A;
+        }
+
+        var bitmap = BitmapSource.Create(
+            width,
+            height,
+            96,
+            96,
+            PixelFormats.Bgra32,
+            null,
+            pixels,
+            width * 4);
+        bitmap.Freeze();
+        return bitmap;
+    }
+
+    private static Color ReadPixel(BitmapSource bitmap, int x, int y)
+    {
+        var formattedBitmap = bitmap.Format == PixelFormats.Bgra32
+            ? bitmap
+            : new FormatConvertedBitmap(bitmap, PixelFormats.Bgra32, null, 0);
+        var bytesPerPixel = (formattedBitmap.Format.BitsPerPixel + 7) / 8;
+        var pixel = new byte[bytesPerPixel];
+        formattedBitmap.CopyPixels(new System.Windows.Int32Rect(x, y, 1, 1), pixel, bytesPerPixel, 0);
+        return Color.FromArgb(pixel[3], pixel[2], pixel[1], pixel[0]);
+    }
+}

--- a/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
+++ b/SnippingTool.Tests/ViewModels/OverlayViewModelTests.cs
@@ -101,6 +101,23 @@ public sealed class OverlayViewModelTests
     }
 
     [Fact]
+    public void InitializeAnnotatingSession_SetsSelectionPhaseAndPixelScale()
+    {
+        // Arrange
+        var vm = Vm();
+        var rect = new Rect(50, 60, 400, 300);
+
+        // Act
+        vm.InitializeAnnotatingSession(rect, 2.5, 1.75);
+
+        // Assert
+        Assert.Equal(rect, vm.SelectionRect);
+        Assert.Equal(OverlayViewModel.Phase.Annotating, vm.CurrentPhase);
+        Assert.Equal(2.5, vm.DpiX);
+        Assert.Equal(1.75, vm.DpiY);
+    }
+
+    [Fact]
     public void UpdateSizeLabel_FormatsWithDpi()
     {
         // Arrange

--- a/SnippingTool/App.xaml
+++ b/SnippingTool/App.xaml
@@ -18,6 +18,7 @@
                 <tb:TaskbarIcon.ContextMenu>
                     <ContextMenu>
                         <MenuItem Header="New Snip" Click="NewSnip_Click" />
+                        <MenuItem Header="Open image..." Click="OpenImage_Click" />
                         <Separator />
                         <MenuItem Header="Settings" Click="Settings_Click" />
                         <MenuItem Header="Check for Updates" Click="CheckForUpdates_Click" />

--- a/SnippingTool/App.xaml.cs
+++ b/SnippingTool/App.xaml.cs
@@ -1,6 +1,8 @@
 using System.Diagnostics;
+using System.IO;
 using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Threading;
 using Hardcodet.Wpf.TaskbarNotification;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -117,6 +119,7 @@ public partial class App : Application
         services.AddSingleton<IAppVersionService, AppVersionService>();
         services.AddSingleton<IClipboardService, ClipboardService>();
         services.AddSingleton<IDialogService, DialogService>();
+        services.AddSingleton<IImageFileService, ImageFileService>();
         services.AddSingleton<IEventAggregator, DefaultEventAggregator>();
         services.AddSingleton<IProcessService, ProcessService>();
         services.AddSingleton<IMessageBoxService, MessageBoxService>();
@@ -201,6 +204,43 @@ public partial class App : Application
 
     private void TrayIcon_LeftClick(object sender, RoutedEventArgs e) => StartSnip();
     private void NewSnip_Click(object sender, RoutedEventArgs e) => StartSnip();
+
+    private void OpenImage_Click(object sender, RoutedEventArgs e)
+    {
+        Dispatcher.InvokeAsync(OpenImage, DispatcherPriority.ApplicationIdle);
+    }
+
+    private void OpenImage()
+    {
+        var dialogService = _host.Services.GetRequiredService<IDialogService>();
+        var selectedPath = dialogService.PickOpenImageFile();
+        if (string.IsNullOrWhiteSpace(selectedPath))
+        {
+            return;
+        }
+
+        try
+        {
+            var imageFileService = _host.Services.GetRequiredService<IImageFileService>();
+            var bitmap = imageFileService.LoadForAnnotation(selectedPath);
+            var overlay = _host.Services.GetRequiredService<OverlayWindow>();
+            overlay.InitializeFromImage(bitmap, selectedPath);
+            overlay.Show();
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or InvalidDataException or NotSupportedException or IOException or UnauthorizedAccessException)
+        {
+            _logger?.LogWarning(ex, "Failed to open image '{Path}'", selectedPath);
+            _messageBox.ShowWarning(ex.Message, "Open Image");
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Unexpected failure while opening image '{Path}'", selectedPath);
+            _messageBox.ShowError(
+                "The selected image could not be opened. Please try a different file.",
+                "Open Image");
+        }
+    }
+
     private void Exit_Click(object sender, RoutedEventArgs e) => Current.Shutdown();
 
 #if DEBUG

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -12,6 +12,7 @@ namespace SnippingTool;
 
 public partial class OverlayWindow : Window
 {
+    private const int ImageViewportMargin = 140;
     private readonly OverlayViewModel _vm;
     private readonly IScreenCaptureService _screenCapture;
     private readonly IScreenRecordingService _recorder;
@@ -28,6 +29,11 @@ public partial class OverlayWindow : Window
     private RecordingBorderWindow? _recordingBorder;
     private RecordingHudWindow? _recordingHud;
     private Point? _lassoStart;
+    private BitmapSource? _openedImage;
+    private string? _openedImagePath;
+    private Rect _openedImageDisplayRect;
+    private double _openedImageScaleX = 1.0;
+    private double _openedImageScaleY = 1.0;
     private BitmapSource? _screenSnapshot;
 
     public OverlayWindow(
@@ -86,6 +92,15 @@ public partial class OverlayWindow : Window
         };
     }
 
+    public void InitializeFromImage(BitmapSource bitmap, string sourcePath)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourcePath);
+
+        _openedImage = bitmap;
+        _openedImagePath = sourcePath;
+    }
+
     protected override void OnSourceInitialized(EventArgs e)
     {
         base.OnSourceInitialized(e);
@@ -105,6 +120,12 @@ public partial class OverlayWindow : Window
         {
             _vm.DpiX = src.CompositionTarget.TransformToDevice.M11;
             _vm.DpiY = src.CompositionTarget.TransformToDevice.M22;
+        }
+
+        if (_openedImage is not null)
+        {
+            InitializeFromOpenedImage(_openedImage);
+            return;
         }
 
         Visibility = Visibility.Hidden;
@@ -244,11 +265,6 @@ public partial class OverlayWindow : Window
     private void TransitionToAnnotating()
     {
         var sel = _vm.SelectionRect;
-        Cursor = Cursors.Arrow;
-        SizeLabelBorder.Visibility = Visibility.Collapsed;
-        DimFull.Visibility = Visibility.Collapsed;
-
-        // Capture clean background pixels for the pixelate tool
         var screenX = (int)((Left + sel.X) * _vm.DpiX);
         var screenY = (int)((Top + sel.Y) * _vm.DpiY);
         var screenW = Math.Max(1, (int)(sel.Width * _vm.DpiX));
@@ -257,15 +273,71 @@ public partial class OverlayWindow : Window
         System.Threading.Thread.Sleep(60);
         var backgroundCapture = _screenCapture.Capture(screenX, screenY, screenW, screenH);
         Visibility = Visibility.Visible;
-        _renderer.SetBackground(backgroundCapture, _vm.DpiX, _vm.DpiY);
         _screenSnapshot = null;
 
-        LayoutDimStrips(sel);
+        EnterAnnotatingSession(sel, backgroundCapture, _vm.DpiX, _vm.DpiY, allowRecording: true);
+    }
 
-        AnnotationCanvas.Width = sel.Width;
-        AnnotationCanvas.Height = sel.Height;
-        Canvas.SetLeft(AnnotationCanvas, sel.X);
-        Canvas.SetTop(AnnotationCanvas, sel.Y);
+    private void InitializeFromOpenedImage(BitmapSource openedImage)
+    {
+        _openedImageDisplayRect = CalculateOpenedImageDisplayRect(openedImage);
+        _openedImageScaleX = openedImage.PixelWidth / _openedImageDisplayRect.Width;
+        _openedImageScaleY = openedImage.PixelHeight / _openedImageDisplayRect.Height;
+
+        _vm.SetBitmapCapture(new OpenedImageBitmapCapture(openedImage, AnnotationCanvas));
+
+        ScreenSnapshot.Source = openedImage;
+        ScreenSnapshot.Width = _openedImageDisplayRect.Width;
+        ScreenSnapshot.Height = _openedImageDisplayRect.Height;
+        Canvas.SetLeft(ScreenSnapshot, _openedImageDisplayRect.X);
+        Canvas.SetTop(ScreenSnapshot, _openedImageDisplayRect.Y);
+
+        EnterAnnotatingSession(
+            _openedImageDisplayRect,
+            openedImage,
+            _openedImageScaleX,
+            _openedImageScaleY,
+            allowRecording: false);
+    }
+
+    private Rect CalculateOpenedImageDisplayRect(BitmapSource openedImage)
+    {
+        var maxWidth = Math.Max(1d, Width - (ImageViewportMargin * 2d));
+        var maxHeight = Math.Max(1d, Height - (ImageViewportMargin * 2d));
+        var scale = Math.Min(maxWidth / openedImage.PixelWidth, maxHeight / openedImage.PixelHeight);
+        scale = Math.Min(1d, scale);
+
+        var displayWidth = Math.Max(1d, openedImage.PixelWidth * scale);
+        var displayHeight = Math.Max(1d, openedImage.PixelHeight * scale);
+        var left = (Width - displayWidth) / 2d;
+        var top = (Height - displayHeight) / 2d;
+
+        return new Rect(left, top, displayWidth, displayHeight);
+    }
+
+    private void EnterAnnotatingSession(Rect selectionRect, BitmapSource backgroundBitmap, double pixelScaleX, double pixelScaleY, bool allowRecording)
+    {
+        _vm.InitializeAnnotatingSession(selectionRect, pixelScaleX, pixelScaleY);
+
+        Cursor = Cursors.Arrow;
+        SizeLabelBorder.Visibility = Visibility.Collapsed;
+        LoupeBorder.Visibility = Visibility.Collapsed;
+        DimFull.Visibility = Visibility.Collapsed;
+
+        Canvas.SetLeft(SelectionBorder, selectionRect.X);
+        Canvas.SetTop(SelectionBorder, selectionRect.Y);
+        SelectionBorder.Width = selectionRect.Width;
+        SelectionBorder.Height = selectionRect.Height;
+        SelectionBorder.Visibility = Visibility.Visible;
+
+        _renderer.SetBackground(backgroundBitmap, pixelScaleX, pixelScaleY);
+
+        LayoutDimStrips(selectionRect);
+
+        AnnotationCanvas.Width = selectionRect.Width;
+        AnnotationCanvas.Height = selectionRect.Height;
+        Canvas.SetLeft(AnnotationCanvas, selectionRect.X);
+        Canvas.SetTop(AnnotationCanvas, selectionRect.Y);
         AnnotationCanvas.Visibility = Visibility.Visible;
         AnnotationCanvas.Cursor = Cursors.Cross;
 
@@ -273,8 +345,10 @@ public partial class OverlayWindow : Window
         AnnotationCanvas.MouseMove += Annot_Move;
         AnnotationCanvas.MouseLeftButtonUp += Annot_Up;
 
-        PositionToolbar(sel);
-        PositionActionBar(sel);
+        RecordBtn.Visibility = allowRecording ? Visibility.Visible : Visibility.Collapsed;
+
+        PositionToolbar(selectionRect);
+        PositionActionBar(selectionRect);
     }
 
     private void LayoutDimStrips(Rect s)

--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -7,6 +7,7 @@ using SnippingTool.Services;
 using SnippingTool.Services.Messaging;
 using SnippingTool.ViewModels;
 using Cursors = System.Windows.Input.Cursors;
+using Forms = System.Windows.Forms;
 
 namespace SnippingTool;
 
@@ -302,17 +303,42 @@ public partial class OverlayWindow : Window
 
     private Rect CalculateOpenedImageDisplayRect(BitmapSource openedImage)
     {
-        var maxWidth = Math.Max(1d, Width - (ImageViewportMargin * 2d));
-        var maxHeight = Math.Max(1d, Height - (ImageViewportMargin * 2d));
-        var scale = Math.Min(maxWidth / openedImage.PixelWidth, maxHeight / openedImage.PixelHeight);
+        return CalculateOpenedImageDisplayRect(
+            openedImage.PixelWidth,
+            openedImage.PixelHeight,
+            GetOpenedImageTargetArea(),
+            ImageViewportMargin);
+    }
+
+    internal static Rect CalculateOpenedImageDisplayRect(
+        double imagePixelWidth,
+        double imagePixelHeight,
+        Rect targetArea,
+        double viewportMargin)
+    {
+        var maxWidth = Math.Max(1d, targetArea.Width - (viewportMargin * 2d));
+        var maxHeight = Math.Max(1d, targetArea.Height - (viewportMargin * 2d));
+        var scale = Math.Min(maxWidth / imagePixelWidth, maxHeight / imagePixelHeight);
         scale = Math.Min(1d, scale);
 
-        var displayWidth = Math.Max(1d, openedImage.PixelWidth * scale);
-        var displayHeight = Math.Max(1d, openedImage.PixelHeight * scale);
-        var left = (Width - displayWidth) / 2d;
-        var top = (Height - displayHeight) / 2d;
+        var displayWidth = Math.Max(1d, imagePixelWidth * scale);
+        var displayHeight = Math.Max(1d, imagePixelHeight * scale);
+        var left = targetArea.Left + ((targetArea.Width - displayWidth) / 2d);
+        var top = targetArea.Top + ((targetArea.Height - displayHeight) / 2d);
 
         return new Rect(left, top, displayWidth, displayHeight);
+    }
+
+    private Rect GetOpenedImageTargetArea()
+    {
+        var targetScreen = Forms.Screen.FromPoint(Forms.Cursor.Position);
+        var workingArea = targetScreen.WorkingArea;
+
+        return new Rect(
+            (workingArea.Left / _vm.DpiX) - Left,
+            (workingArea.Top / _vm.DpiY) - Top,
+            workingArea.Width / _vm.DpiX,
+            workingArea.Height / _vm.DpiY);
     }
 
     private void EnterAnnotatingSession(Rect selectionRect, BitmapSource backgroundBitmap, double pixelScaleX, double pixelScaleY, bool allowRecording)

--- a/SnippingTool/Services/DialogService.cs
+++ b/SnippingTool/Services/DialogService.cs
@@ -1,9 +1,30 @@
+using System.Windows;
+using System.Windows.Interop;
 using Forms = System.Windows.Forms;
 
 namespace SnippingTool.Services;
 
 public sealed class DialogService : IDialogService
 {
+    public string? PickOpenImageFile()
+    {
+        using var dialog = new Forms.OpenFileDialog
+        {
+            Title = "Open image",
+            Filter = "Image files (*.png;*.jpg;*.jpeg;*.bmp)|*.png;*.jpg;*.jpeg;*.bmp",
+            CheckFileExists = true,
+            CheckPathExists = true,
+            Multiselect = false
+        };
+
+        using var owner = CreateDialogOwner();
+        var result = dialog.ShowDialog(owner);
+
+        return result == Forms.DialogResult.OK
+            ? dialog.FileName
+            : null;
+    }
+
     public string? PickFolder(string initialPath, string description)
     {
         using var dialog = new Forms.FolderBrowserDialog
@@ -32,5 +53,110 @@ public sealed class DialogService : IDialogService
 
         var selectedColor = dialog.Color;
         return Color.FromArgb(selectedColor.A, selectedColor.R, selectedColor.G, selectedColor.B);
+    }
+
+    private static DialogOwner CreateDialogOwner()
+    {
+        var existingOwner = GetOwnerWindowHandle();
+        if (existingOwner != IntPtr.Zero)
+        {
+            return new ExistingDialogOwner(existingOwner);
+        }
+
+        return TemporaryDialogOwner.Create();
+    }
+
+    private static IntPtr GetOwnerWindowHandle()
+    {
+        var application = System.Windows.Application.Current;
+        if (application is null)
+        {
+            return IntPtr.Zero;
+        }
+
+        foreach (Window window in application.Windows)
+        {
+            if (window.IsActive)
+            {
+                var handle = new WindowInteropHelper(window).Handle;
+                if (handle != IntPtr.Zero)
+                {
+                    return handle;
+                }
+            }
+        }
+
+        foreach (Window window in application.Windows)
+        {
+            if (window.IsVisible)
+            {
+                var handle = new WindowInteropHelper(window).Handle;
+                if (handle != IntPtr.Zero)
+                {
+                    return handle;
+                }
+            }
+        }
+
+        return IntPtr.Zero;
+    }
+
+    private abstract class DialogOwner : Forms.IWin32Window, IDisposable
+    {
+        public abstract IntPtr Handle { get; }
+
+        public virtual void Dispose()
+        {
+        }
+    }
+
+    private sealed class ExistingDialogOwner : DialogOwner
+    {
+        public ExistingDialogOwner(IntPtr handle)
+        {
+            Handle = handle;
+        }
+
+        public override IntPtr Handle { get; }
+    }
+
+    private sealed class TemporaryDialogOwner : DialogOwner
+    {
+        private readonly Window _window;
+
+        private TemporaryDialogOwner(Window window)
+        {
+            _window = window;
+            Handle = new WindowInteropHelper(window).Handle;
+        }
+
+        public override IntPtr Handle { get; }
+
+        public static TemporaryDialogOwner Create()
+        {
+            var window = new Window
+            {
+                Width = 1,
+                Height = 1,
+                Left = -10000,
+                Top = -10000,
+                WindowStyle = WindowStyle.None,
+                ResizeMode = ResizeMode.NoResize,
+                ShowInTaskbar = false,
+                ShowActivated = true,
+                Topmost = true,
+                Opacity = 0
+            };
+
+            window.Show();
+            window.Activate();
+
+            return new TemporaryDialogOwner(window);
+        }
+
+        public override void Dispose()
+        {
+            _window.Close();
+        }
     }
 }

--- a/SnippingTool/Services/IDialogService.cs
+++ b/SnippingTool/Services/IDialogService.cs
@@ -2,6 +2,8 @@ namespace SnippingTool.Services;
 
 public interface IDialogService
 {
+    string? PickOpenImageFile();
+
     string? PickFolder(string initialPath, string description);
 
     Color? PickColor(Color initialColor);

--- a/SnippingTool/Services/IImageFileService.cs
+++ b/SnippingTool/Services/IImageFileService.cs
@@ -1,0 +1,8 @@
+using System.Windows.Media.Imaging;
+
+namespace SnippingTool.Services;
+
+public interface IImageFileService
+{
+    BitmapSource LoadForAnnotation(string path);
+}

--- a/SnippingTool/Services/ImageFileService.cs
+++ b/SnippingTool/Services/ImageFileService.cs
@@ -1,0 +1,46 @@
+using System.IO;
+using System.Windows.Media.Imaging;
+
+namespace SnippingTool.Services;
+
+public sealed class ImageFileService : IImageFileService
+{
+    private static readonly HashSet<string> SupportedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".bmp"
+    };
+
+    public BitmapSource LoadForAnnotation(string path)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(path);
+
+        var extension = Path.GetExtension(path);
+        if (!SupportedExtensions.Contains(extension))
+        {
+            throw new NotSupportedException($"Unsupported image format '{extension}'. Supported formats are PNG, JPG, JPEG, and BMP.");
+        }
+
+        if (!File.Exists(path))
+        {
+            throw new FileNotFoundException("The selected image file was not found.", path);
+        }
+
+        try
+        {
+            using var stream = File.OpenRead(path);
+            var bitmap = BitmapFrame.Create(
+                stream,
+                BitmapCreateOptions.PreservePixelFormat,
+                BitmapCacheOption.OnLoad);
+            bitmap.Freeze();
+            return bitmap;
+        }
+        catch (Exception ex) when (ex is NotSupportedException or FileFormatException)
+        {
+            throw new InvalidDataException("The selected image file could not be opened as a supported bitmap.", ex);
+        }
+    }
+}

--- a/SnippingTool/Services/OpenedImageBitmapCapture.cs
+++ b/SnippingTool/Services/OpenedImageBitmapCapture.cs
@@ -1,0 +1,70 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+
+namespace SnippingTool.Services;
+
+internal sealed class OpenedImageBitmapCapture : IOverlayBitmapCapture
+
+{
+    private readonly BitmapSource _sourceBitmap;
+    private readonly Canvas _annotationCanvas;
+
+    public OpenedImageBitmapCapture(BitmapSource sourceBitmap, Canvas annotationCanvas)
+    {
+        _sourceBitmap = sourceBitmap;
+        _annotationCanvas = annotationCanvas;
+    }
+
+    public BitmapSource ComposeBitmap()
+    {
+        var displayWidth = GetDisplayDimension(_annotationCanvas.Width, _annotationCanvas.ActualWidth);
+        var displayHeight = GetDisplayDimension(_annotationCanvas.Height, _annotationCanvas.ActualHeight);
+        _annotationCanvas.Measure(new Size(displayWidth, displayHeight));
+        _annotationCanvas.Arrange(new Rect(0, 0, displayWidth, displayHeight));
+        _annotationCanvas.UpdateLayout();
+
+        var drawingVisual = new DrawingVisual();
+        using (var drawingContext = drawingVisual.RenderOpen())
+        {
+            var targetRect = new Rect(0, 0, _sourceBitmap.PixelWidth, _sourceBitmap.PixelHeight);
+            drawingContext.DrawImage(_sourceBitmap, targetRect);
+
+            var annotationBrush = new VisualBrush(_annotationCanvas)
+            {
+                Stretch = Stretch.Fill,
+                AlignmentX = AlignmentX.Left,
+                AlignmentY = AlignmentY.Top
+            };
+            drawingContext.DrawRectangle(annotationBrush, null, targetRect);
+        }
+
+        var dpiX = _sourceBitmap.DpiX > 0 ? _sourceBitmap.DpiX : 96;
+        var dpiY = _sourceBitmap.DpiY > 0 ? _sourceBitmap.DpiY : 96;
+        var finalBitmap = new RenderTargetBitmap(
+            _sourceBitmap.PixelWidth,
+            _sourceBitmap.PixelHeight,
+            dpiX,
+            dpiY,
+            PixelFormats.Pbgra32);
+        finalBitmap.Render(drawingVisual);
+        finalBitmap.Freeze();
+        return finalBitmap;
+    }
+
+    private static double GetDisplayDimension(double preferredValue, double actualValue)
+    {
+        if (preferredValue > 0)
+        {
+            return preferredValue;
+        }
+
+        if (actualValue > 0)
+        {
+            return actualValue;
+        }
+
+        return 1d;
+    }
+}

--- a/SnippingTool/ViewModels/OverlayViewModel.cs
+++ b/SnippingTool/ViewModels/OverlayViewModel.cs
@@ -52,10 +52,17 @@ public partial class OverlayViewModel : AnnotationViewModel
     [ObservableProperty]
     private bool _isTextLassoActive;
 
-    public void CommitSelection(Rect selection)
+    public void InitializeAnnotatingSession(Rect selection, double pixelScaleX, double pixelScaleY)
     {
         SelectionRect = selection;
+        DpiX = pixelScaleX;
+        DpiY = pixelScaleY;
         CurrentPhase = Phase.Annotating;
+    }
+
+    public void CommitSelection(Rect selection)
+    {
+        InitializeAnnotatingSession(selection, DpiX, DpiY);
         _logger.LogInformation("Selection committed: {W:F0}\u00d7{H:F0} at ({X:F0},{Y:F0})",
             selection.Width, selection.Height, selection.X, selection.Y);
     }


### PR DESCRIPTION
Users can now load PNG, JPG/JPEG, or BMP files from the tray menu for annotation without taking a new screenshot. Added new menu item, DI registration, and error handling for image loading. Introduced IImageFileService and OpenedImageBitmapCapture for bitmap composition. Updated OverlayWindow and OverlayViewModel for image session support. Extended DialogService for file selection. Added unit tests for image loading and bitmap composition. Updated README.md to document the new feature.