### PR TITLE
Defer pin window and improve annotation rendering

### DIFF
--- a/SnippingTool/OverlayWindow.xaml.cs
+++ b/SnippingTool/OverlayWindow.xaml.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 using Microsoft.Extensions.Logging;
 using SnippingTool.Services;
 using SnippingTool.Services.Messaging;
@@ -36,6 +37,7 @@ public partial class OverlayWindow : Window
     private double _openedImageScaleX = 1.0;
     private double _openedImageScaleY = 1.0;
     private BitmapSource? _screenSnapshot;
+    private BitmapSource? _pendingPinnedBitmap;
 
     public OverlayWindow(
         OverlayViewModel vm,
@@ -593,6 +595,9 @@ public partial class OverlayWindow : Window
 
     protected override void OnClosed(EventArgs e)
     {
+        var pendingPinnedBitmap = _pendingPinnedBitmap;
+        _pendingPinnedBitmap = null;
+
         _undoSubscription.Dispose();
         _redoSubscription.Dispose();
 
@@ -607,6 +612,17 @@ public partial class OverlayWindow : Window
         _recordingBorder = null;
 
         base.OnClosed(e);
+
+        if (pendingPinnedBitmap is not null)
+        {
+            Dispatcher.BeginInvoke(
+                DispatcherPriority.ApplicationIdle,
+                new Action(() =>
+                {
+                    var pinned = new PinnedScreenshotWindow(pendingPinnedBitmap);
+                    pinned.Show();
+                }));
+        }
     }
 
     private ValueTask HandleUndoGroupAsync(UndoGroupMessage message)
@@ -640,9 +656,9 @@ public partial class OverlayWindow : Window
 
     private void DoPin(BitmapSource bitmap)
     {
-        var pinned = new PinnedScreenshotWindow(bitmap);
-        pinned.Show();
-        Close();
+        _pendingPinnedBitmap = bitmap;
+        Visibility = Visibility.Hidden;
+        Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, new Action(Close));
     }
 
     private async Task DoLassoOcrAsync(Rect lassoRect)

--- a/SnippingTool/Services/OpenedImageBitmapCapture.cs
+++ b/SnippingTool/Services/OpenedImageBitmapCapture.cs
@@ -6,7 +6,6 @@ using System.Windows.Media.Imaging;
 namespace SnippingTool.Services;
 
 internal sealed class OpenedImageBitmapCapture : IOverlayBitmapCapture
-
 {
     private readonly BitmapSource _sourceBitmap;
     private readonly Canvas _annotationCanvas;

--- a/SnippingTool/Services/OverlayBitmapCapture.cs
+++ b/SnippingTool/Services/OverlayBitmapCapture.cs
@@ -2,6 +2,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using System.Windows.Threading;
 
 namespace SnippingTool.Services;
 
@@ -48,6 +49,7 @@ internal sealed class OverlayBitmapCapture : IOverlayBitmapCapture
         try
         {
             _overlayWindow.Visibility = Visibility.Hidden;
+            FlushDispatcher(_overlayWindow.Dispatcher, DispatcherPriority.Render);
             System.Threading.Thread.Sleep(CaptureHideDelayMs);
             screenBitmap = _screenCapture.Capture(screenX, screenY, screenWidth, screenHeight);
         }
@@ -59,20 +61,64 @@ internal sealed class OverlayBitmapCapture : IOverlayBitmapCapture
             }
         }
 
-        var annotationBitmap = new RenderTargetBitmap(screenWidth, screenHeight, 96 * dpiX, 96 * dpiY, PixelFormats.Pbgra32);
-        annotationBitmap.Render(_annotationCanvas);
+        var displayWidth = GetDisplayDimension(_annotationCanvas.Width, _annotationCanvas.ActualWidth);
+        var displayHeight = GetDisplayDimension(_annotationCanvas.Height, _annotationCanvas.ActualHeight);
+        _annotationCanvas.Measure(new Size(displayWidth, displayHeight));
+        _annotationCanvas.Arrange(new Rect(0, 0, displayWidth, displayHeight));
+        _annotationCanvas.UpdateLayout();
 
         var drawingVisual = new DrawingVisual();
         using (var drawingContext = drawingVisual.RenderOpen())
         {
             var targetRect = new Rect(0, 0, screenBitmap.PixelWidth, screenBitmap.PixelHeight);
             drawingContext.DrawImage(screenBitmap, targetRect);
-            drawingContext.DrawImage(annotationBitmap, targetRect);
+
+            var annotationBrush = new VisualBrush(_annotationCanvas)
+            {
+                Stretch = Stretch.Fill,
+                AlignmentX = AlignmentX.Left,
+                AlignmentY = AlignmentY.Top
+            };
+            drawingContext.DrawRectangle(annotationBrush, null, targetRect);
         }
 
         var finalBitmap = new RenderTargetBitmap(screenBitmap.PixelWidth, screenBitmap.PixelHeight, 96, 96, PixelFormats.Pbgra32);
         finalBitmap.Render(drawingVisual);
         finalBitmap.Freeze();
         return finalBitmap;
+    }
+
+    private static double GetDisplayDimension(double preferredValue, double actualValue)
+    {
+        if (preferredValue > 0)
+        {
+            return preferredValue;
+        }
+
+        if (actualValue > 0)
+        {
+            return actualValue;
+        }
+
+        return 1d;
+    }
+
+    private static void FlushDispatcher(Dispatcher dispatcher, DispatcherPriority priority)
+    {
+        if (dispatcher.HasShutdownStarted || dispatcher.HasShutdownFinished)
+        {
+            return;
+        }
+
+        var frame = new DispatcherFrame();
+        dispatcher.BeginInvoke(
+            priority,
+            new DispatcherOperationCallback(static state =>
+            {
+                ((DispatcherFrame)state!).Continue = false;
+                return null;
+            }),
+            frame);
+        Dispatcher.PushFrame(frame);
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "3.5",
+  "version": "3.6",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
OverlayWindow now defers opening PinnedScreenshotWindow until after closing to prevent UI glitches. OverlayBitmapCapture measures and arranges the annotation canvas before capture, and uses a VisualBrush for accurate rendering. Added GetDisplayDimension and FlushDispatcher utilities for sizing and dispatcher flushing.