### PR TITLE
docs: Add GitHub Pages landing page and workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,40 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["master", "main"]
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+        
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # Upload entire repository
+          path: './website'
+          
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,10 +11,10 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# Allow only one Pages deployment at a time and let the newest run supersede older ones.
 concurrency:
   group: "pages"
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -32,7 +32,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          # Upload entire repository
+          # Publish the static landing page from the website directory
           path: './website'
           
       - name: Deploy to GitHub Pages

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 </p>
 
 <p align="center">
+  <b>🌐 <a href="https://dimitar-radenkov.github.io/SnippingTool/">Visit the Official Website</a></b>
+</p>
+
+<p align="center">
   <a href="https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml"><img src="https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="https://codecov.io/gh/dimitar-radenkov/SnippingTool"><img src="https://codecov.io/gh/dimitar-radenkov/SnippingTool/branch/master/graph/badge.svg" alt="codecov"></a>
   <a href="https://github.com/dimitar-radenkov/SnippingTool/releases/latest"><img src="https://img.shields.io/github/v/release/dimitar-radenkov/SnippingTool?color=success" alt="Latest release"></a>

--- a/README.md
+++ b/README.md
@@ -1,20 +1,38 @@
-# SnippingTool
+# ✂️ SnippingTool
 
-[![CI](https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml/badge.svg)](https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/dimitar-radenkov/SnippingTool/branch/master/graph/badge.svg)](https://codecov.io/gh/dimitar-radenkov/SnippingTool)
-[![Downloads](https://img.shields.io/github/downloads/dimitar-radenkov/SnippingTool/total?label=downloads&color=blue)](https://github.com/dimitar-radenkov/SnippingTool/releases)
-[![Latest release](https://img.shields.io/github/v/release/dimitar-radenkov/SnippingTool)](https://github.com/dimitar-radenkov/SnippingTool/releases/latest)
-[![winget](https://img.shields.io/winget/v/DimitarRadenkov.SnippingTool?label=winget)](https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/DimitarRadenkov/SnippingTool)
+<p align="center">
+  <b>A modern, lightning-fast screen capture and recording tool for Windows, built on .NET 10.</b><br>
+  Record your screen, add live annotations without breaking your flow, and redact sensitive data on the fly.
+</p>
 
-Record your screen with live annotations.
+<p align="center">
+  <a href="https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml"><img src="https://github.com/dimitar-radenkov/SnippingTool/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/dimitar-radenkov/SnippingTool"><img src="https://codecov.io/gh/dimitar-radenkov/SnippingTool/branch/master/graph/badge.svg" alt="codecov"></a>
+  <a href="https://github.com/dimitar-radenkov/SnippingTool/releases/latest"><img src="https://img.shields.io/github/v/release/dimitar-radenkov/SnippingTool?color=success" alt="Latest release"></a>
+  <a href="https://github.com/microsoft/winget-pkgs/tree/master/manifests/d/DimitarRadenkov/SnippingTool"><img src="https://img.shields.io/winget/v/DimitarRadenkov.SnippingTool?label=winget&color=blue" alt="winget"></a>
+  <a href="https://github.com/dimitar-radenkov/SnippingTool/releases"><img src="https://img.shields.io/github/downloads/dimitar-radenkov/SnippingTool/total?label=downloads&color=purple" alt="Downloads"></a>
+</p>
 
-SnippingTool helps you explain what’s on your screen without turning it into a post-editing job. It is built for demos, tutorials, and bug reports when you want to show something clearly and move on. Draw, blur, and add callouts while recording, then burn everything straight into the final video.
+<p align="center">
+  <video src="https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949" width="100%" controls autoplay loop muted></video>
+</p>
 
-Get it in seconds: [Download the latest release](https://github.com/dimitar-radenkov/SnippingTool/releases) · `winget install DimitarRadenkov.SnippingTool`
+## 🚀 Quick Start
 
-## Demo
+Get up and running in seconds using the Windows Package Manager (winget):
 
-https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949
+```powershell
+winget install DimitarRadenkov.SnippingTool
+```
+
+*Prefer a manual install? Download the latest `SnippingTool-Setup-*.exe` from the [Releases](https://github.com/dimitar-radenkov/SnippingTool/releases) page.*
+
+## ✨ Why use this over the built-in Windows tool?
+
+- **Live Video Annotations:** Draw, highlight, and redact *while* recording. No need for post-production video editing.
+- **Privacy First (Live Blur):** Drag over sensitive content (passwords, emails, API keys) to apply a live Gaussian blur that stays hidden in the final export.
+- **Built-in OCR:** Lasso any text on your screen (even in images or videos) to instantly copy it to your clipboard.
+- **Pin to Screen:** Pin captured screenshots as floating, always-on-top windows for quick reference while coding or writing.
 
 ## Latest features
 
@@ -198,6 +216,15 @@ To bump the version:
 - **Hardcodet.Wpf.TaskbarNotification** — system tray icon
 - **Nerdbank.GitVersioning** — automatic semantic versioning from git history
 - **xUnit** — unit tests
+
+## 🤝 Contributing
+
+We welcome contributions! Whether it's reporting a bug, suggesting a feature, or submitting a pull request. 
+SnippingTool is built on a very clean, modern stack (.NET 10, WPF, CommunityToolkit.Mvvm) making it a great jumping-off point for developers.
+
+1. Check out our [Developer Guide](docs/developer-guide.md) and [Architecture Knowledge Base](docs/project-knowledge-base.md).
+2. Browse our [Planned Features](docs/planned-features.md) or look for issues tagged `good first issue`.
+3. Open a Pull Request!
 
 ## Privacy
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ winget install DimitarRadenkov.SnippingTool
 
 *Prefer a manual install? Download the latest `SnippingTool-Setup-*.exe` from the [Releases](https://github.com/dimitar-radenkov/SnippingTool/releases) page.*
 
+1. Install SnippingTool with `winget install DimitarRadenkov.SnippingTool` or download the latest installer from [Releases](https://github.com/dimitar-radenkov/SnippingTool/releases).
+2. Press `Print Screen` to open the capture overlay and select the region you want.
+3. Annotate, copy, save, pin, or record the region from the overlay and recording HUD.
+
 ## ✨ Why use this over the built-in Windows tool?
 
 - **Live Video Annotations:** Draw, highlight, and redact *while* recording. No need for post-production video editing.
@@ -50,12 +54,6 @@ winget install DimitarRadenkov.SnippingTool
 - **Make tutorials easier to follow** — Arrows, text, and numbered steps keep people focused on what matters.
 - **Hide private details before sharing** — Blur emails, passwords, tokens, and anything else you do not want on screen.
 - **Work from one place** — Capture, annotate, copy, save, pin, and record without bouncing between tools.
-
-## Quick start
-
-1. Install SnippingTool with `winget install DimitarRadenkov.SnippingTool` or download the latest installer from [Releases](https://github.com/dimitar-radenkov/SnippingTool/releases).
-2. Press `Print Screen` to open the capture overlay and select the region you want.
-3. Annotate, copy, save, pin, or record the region from the overlay and recording HUD.
 
 ## Features
 
@@ -223,7 +221,7 @@ To bump the version:
 
 ## 🤝 Contributing
 
-We welcome contributions! Whether it's reporting a bug, suggesting a feature, or submitting a pull request. 
+We welcome contributions! Whether it's reporting a bug, suggesting a feature, or submitting a pull request.
 SnippingTool is built on a very clean, modern stack (.NET 10, WPF, CommunityToolkit.Mvvm) making it a great jumping-off point for developers.
 
 1. Check out our [Developer Guide](docs/developer-guide.md) and [Architecture Knowledge Base](docs/project-knowledge-base.md).

--- a/website/index.html
+++ b/website/index.html
@@ -3,9 +3,50 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SnippingTool - Modern Screen Capture & Recording for Windows</title>
-    <meta name="description" content="A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations without breaking your flow, and redact sensitive data on the fly.">
+    <title>SnippingTool - Free Screen Capture, OCR, and Screen Recorder for Windows</title>
+    <meta name="description" content="Free screen capture, OCR, and screen recorder for Windows with live annotations, blur redaction, and pinned screenshots. A lightweight Snagit, Greenshot, ShareX, and Windows Snipping Tool alternative.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://dimitar-radenkov.github.io/SnippingTool/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="SnippingTool - Free Screen Capture, OCR, and Screen Recorder for Windows">
+    <meta property="og:description" content="Capture screenshots, record your screen, annotate live, blur sensitive data, and extract text with OCR on Windows.">
+    <meta property="og:url" content="https://dimitar-radenkov.github.io/SnippingTool/">
+    <meta property="og:site_name" content="SnippingTool">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="SnippingTool - Free Screen Capture, OCR, and Screen Recorder for Windows">
+    <meta name="twitter:description" content="A lightweight Windows screenshot and screen recording tool with live annotations, OCR, blur, and pinned screenshots.">
     <link rel="stylesheet" href="./styles.css">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "SoftwareApplication",
+            "name": "SnippingTool",
+            "applicationCategory": "UtilitiesApplication",
+            "applicationSubCategory": "Screen Capture Tool",
+            "operatingSystem": "Windows 10, Windows 11",
+            "description": "Free screen capture, OCR, and screen recording tool for Windows with live annotations, blur redaction, and pinned screenshots.",
+            "downloadUrl": "https://github.com/dimitar-radenkov/SnippingTool/releases/latest",
+            "url": "https://dimitar-radenkov.github.io/SnippingTool/",
+            "softwareVersion": "Latest",
+            "offers": {
+                "@type": "Offer",
+                "price": "0",
+                "priceCurrency": "USD"
+            },
+            "creator": {
+                "@type": "Person",
+                "name": "Dimitar Radenkov"
+            },
+            "keywords": [
+                "screen capture tool for Windows",
+                "screen recorder with annotations",
+                "OCR from screenshot",
+                "Snagit alternative",
+                "Greenshot alternative",
+                "ShareX alternative"
+            ]
+        }
+    </script>
 </head>
 <body>
 
@@ -18,6 +59,7 @@
             </a>
             <div class="nav-links">
                 <a href="#features" class="nav-link">Features</a>
+                <a href="#compare" class="nav-link">Compare</a>
                 <a href="https://github.com/dimitar-radenkov/SnippingTool" target="_blank" rel="noopener noreferrer" class="github-link" aria-label="Open SnippingTool on GitHub">
                         <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
@@ -30,12 +72,12 @@
     <!-- Hero Section -->
     <main id="top" class="hero">
         <div class="container hero-panel">
-            <p class="hero-eyebrow">Built for tutorials, bug reports, and fast feedback</p>
+            <p class="hero-eyebrow">Free Windows screenshot and screen recording tool for tutorials, bug reports, and fast feedback</p>
             <h1 class="hero-title">
-                Capture & Record like a <span class="gradient-text">Pro</span>
+                Free Screen Capture, OCR, and <span class="gradient-text">Screen Recording</span> for Windows
             </h1>
             <p class="hero-copy">
-                A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations to explain your point, and redact sensitive data on the fly.
+                SnippingTool is a lightweight Windows screen capture and screen recorder with live annotations, OCR text extraction, blur redaction, and pinned screenshots. It is built for anyone who wants a faster alternative to Windows Snipping Tool, ShareX, Greenshot, or Snagit.
             </p>
             
             <div class="hero-actions">
@@ -68,8 +110,8 @@
     <section id="features" class="section">
         <div class="container">
             <div class="section-header">
-                <h2 class="section-title">Why use this over the built-in Windows tool?</h2>
-                <p class="section-copy">Built for speed, privacy, and seamless communication.</p>
+                <h2 class="section-title">Why this Windows screenshot and screen recording tool stands out</h2>
+                <p class="section-copy">Built for fast screen capture, live explanation, and sharing without post-editing friction.</p>
             </div>
 
             <div class="feature-grid">
@@ -108,6 +150,35 @@
                     <h3 class="feature-title">Pin to Screen</h3>
                     <p class="feature-copy">Working on something complex? Pin a captured screenshot as a floating, always-on-top window for quick reference while you code or type.</p>
                 </article>
+            </div>
+        </div>
+    </section>
+
+    <section id="compare" class="section section-alt">
+        <div class="container">
+            <div class="section-header">
+                <h2 class="section-title">A practical alternative to Windows Snipping Tool, ShareX, Greenshot, and Snagit</h2>
+                <p class="section-copy">People usually find SnippingTool when they need a Windows screenshot tool with cleaner recording, easier annotation, or built-in OCR.</p>
+            </div>
+
+            <div class="comparison-grid">
+                <article class="comparison-card">
+                    <h3 class="comparison-title">Compared with Windows Snipping Tool</h3>
+                    <p class="comparison-copy">SnippingTool adds live recording annotations, built-in OCR, blur redaction, pinned screenshots, and faster explanation workflows for bug reports and tutorials.</p>
+                </article>
+                <article class="comparison-card">
+                    <h3 class="comparison-title">Compared with ShareX and Greenshot</h3>
+                    <p class="comparison-copy">SnippingTool focuses on a simpler day-to-day capture experience with fewer setup steps, a cleaner UI, and quick access to the exact tools most people use constantly.</p>
+                </article>
+                <article class="comparison-card">
+                    <h3 class="comparison-title">Compared with Snagit</h3>
+                    <p class="comparison-copy">SnippingTool gives you a free Windows screen capture and recording workflow with live markup, blur, and OCR without requiring a paid license.</p>
+                </article>
+            </div>
+
+            <div class="seo-copy-block">
+                <p>If you are searching for a free screen capture tool for Windows, a screen recorder with annotations, or a way to copy text from screenshots on Windows, this is the exact problem space SnippingTool is designed for.</p>
+                <p>It works well for software demos, support tickets, bug reports, internal documentation, step-by-step tutorials, and any workflow where you need to show the important part of the screen quickly and clearly.</p>
             </div>
         </div>
     </section>

--- a/website/index.html
+++ b/website/index.html
@@ -1,0 +1,148 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SnippingTool - Modern Screen Capture & Recording for Windows</title>
+    <meta name="description" content="A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations without breaking your flow, and redact sensitive data on the fly.">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <style>
+        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
+        body {
+            font-family: 'Inter', sans-serif;
+            background-color: #f8fafc;
+        }
+        .gradient-text {
+            background: linear-gradient(to right, #3b82f6, #8b5cf6);
+            -webkit-background-clip: text;
+            background-clip: text;
+            color: transparent;
+        }
+    </style>
+</head>
+<body class="text-gray-800 antialiased selection:bg-blue-200">
+
+    <!-- Navigation -->
+    <nav class="bg-white/80 backdrop-blur-md sticky top-0 z-50 border-b border-gray-200">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between items-center h-16">
+                <div class="flex items-center gap-2">
+                    <span class="text-2xl">✂️</span>
+                    <span class="font-bold text-xl tracking-tight text-gray-900">SnippingTool</span>
+                </div>
+                <div class="flex items-center space-x-6">
+                    <a href="#features" class="text-gray-600 hover:text-blue-600 font-medium transition-colors hidden sm:block">Features</a>
+                    <a href="https://github.com/dimitar-radenkov/SnippingTool" target="_blank" rel="noopener noreferrer" class="text-gray-600 hover:text-gray-900 transition-colors">
+                        <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
+                            <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- Hero Section -->
+    <main class="pt-20 pb-16 sm:pt-24 sm:pb-20 lg:pb-24">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+            <h1 class="text-5xl sm:text-6xl font-extrabold tracking-tight text-gray-900 mb-6">
+                Capture & Record like a <span class="gradient-text">Pro</span>
+            </h1>
+            <p class="mt-4 text-xl text-gray-600 max-w-3xl mx-auto mb-10 leading-relaxed">
+                A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations to explain your point, and redact sensitive data on the fly.
+            </p>
+            
+            <div class="flex flex-col sm:flex-row justify-center items-center gap-4 mb-16">
+                <a href="https://github.com/dimitar-radenkov/SnippingTool/releases/latest" class="inline-flex items-center justify-center px-8 py-4 text-base font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 transform hover:-translate-y-1 w-full sm:w-auto">
+                    <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
+                    Download for Windows
+                </a>
+                
+                <div class="bg-gray-100 border border-gray-200 rounded-lg px-6 py-4 flex items-center gap-3 w-full sm:w-auto shadow-inner group relative cursor-pointer" onclick="navigator.clipboard.writeText('winget install DimitarRadenkov.SnippingTool'); alert('Command copied to clipboard!');">
+                    <div class="font-mono text-sm text-gray-700">
+                        <span class="text-gray-400">$</span> winget install DimitarRadenkov.SnippingTool
+                    </div>
+                    <button class="text-gray-400 hover:text-blue-600 transition-colors" title="Copy command">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                    </button>
+                    <!-- Tooltip -->
+                    <div class="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs py-1 px-2 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
+                        Click to copy
+                    </div>
+                </div>
+            </div>
+
+            <!-- Video Demo -->
+            <div class="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white max-w-5xl mx-auto transform hover:scale-[1.01] transition-transform duration-500">
+                <div class="absolute inset-0 bg-gradient-to-t from-gray-900/10 to-transparent pointer-events-none z-10"></div>
+                <video src="https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949" class="w-full h-auto" autoplay loop muted playsinline controls></video>
+            </div>
+        </div>
+    </main>
+
+    <!-- Features Section -->
+    <section id="features" class="py-20 bg-white border-t border-gray-100">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="text-center mb-16">
+                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">Why use this over the built-in Windows tool?</h2>
+                <p class="mt-4 text-lg text-gray-600">Built for speed, privacy, and seamless communication.</p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+                <!-- Feature 1 -->
+                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-blue-200 hover:shadow-md transition-all">
+                    <div class="w-12 h-12 bg-blue-100 text-blue-600 rounded-xl flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-3">Live Video Annotations</h3>
+                    <p class="text-gray-600 leading-relaxed">Draw, highlight, and point things out <em>while</em> you are recording. No need for complicated post-production video editing to explain a bug or tutorial.</p>
+                </div>
+
+                <!-- Feature 2 -->
+                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-purple-200 hover:shadow-md transition-all">
+                    <div class="w-12 h-12 bg-purple-100 text-purple-600 rounded-xl flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"></path></svg>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-3">Privacy First (Live Blur)</h3>
+                    <p class="text-gray-600 leading-relaxed">Drag over sensitive content (passwords, emails, API keys) to apply a Gaussian blur instantly. It stays blurred even in your exported video recordings.</p>
+                </div>
+
+                <!-- Feature 3 -->
+                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-green-200 hover:shadow-md transition-all">
+                    <div class="w-12 h-12 bg-green-100 text-green-600 rounded-xl flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path></svg>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-3">Built-in OCR (Text Extraction)</h3>
+                    <p class="text-gray-600 leading-relaxed">Can't copy text from an image or video? Just lasso the text on your screen with SnippingTool, and it instantly extracts and copies it to your clipboard.</p>
+                </div>
+
+                <!-- Feature 4 -->
+                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-orange-200 hover:shadow-md transition-all">
+                    <div class="w-12 h-12 bg-orange-100 text-orange-600 rounded-xl flex items-center justify-center mb-6">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path></svg>
+                    </div>
+                    <h3 class="text-xl font-bold text-gray-900 mb-3">Pin to Screen</h3>
+                    <p class="text-gray-600 leading-relaxed">Working on something complex? Pin a captured screenshot as a floating, always-on-top window for quick reference while you code or type.</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- Footer -->
+    <footer class="bg-gray-900 text-white py-12">
+        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center gap-6">
+            <div class="flex items-center gap-2">
+                <span class="text-2xl">✂️</span>
+                <span class="font-bold text-xl tracking-tight">SnippingTool</span>
+            </div>
+            
+            <div class="flex space-x-6 text-sm text-gray-400 text-center md:text-left">
+                <span>Built on .NET 10, WPF, and MVVM</span>
+                <a href="https://github.com/dimitar-radenkov/SnippingTool/issues" class="hover:text-white transition-colors">Report an Issue</a>
+                <a href="https://github.com/dimitar-radenkov/SnippingTool" class="hover:text-white transition-colors">Source Code</a>
+            </div>
+        </div>
+    </footer>
+
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -1,148 +1,196 @@
 <!DOCTYPE html>
-<html lang="en" class="scroll-smooth">
+<html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SnippingTool - Modern Screen Capture & Recording for Windows</title>
     <meta name="description" content="A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations without breaking your flow, and redact sensitive data on the fly.">
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
-        body {
-            font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
-        }
-        .gradient-text {
-            background: linear-gradient(to right, #3b82f6, #8b5cf6);
-            -webkit-background-clip: text;
-            background-clip: text;
-            color: transparent;
-        }
-    </style>
+    <link rel="stylesheet" href="./styles.css">
 </head>
-<body class="text-gray-800 antialiased selection:bg-blue-200">
+<body>
 
     <!-- Navigation -->
-    <nav class="bg-white/80 backdrop-blur-md sticky top-0 z-50 border-b border-gray-200">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="flex justify-between items-center h-16">
-                <div class="flex items-center gap-2">
-                    <span class="text-2xl">✂️</span>
-                    <span class="font-bold text-xl tracking-tight text-gray-900">SnippingTool</span>
-                </div>
-                <div class="flex items-center space-x-6">
-                    <a href="#features" class="text-gray-600 hover:text-blue-600 font-medium transition-colors hidden sm:block">Features</a>
-                    <a href="https://github.com/dimitar-radenkov/SnippingTool" target="_blank" rel="noopener noreferrer" class="text-gray-600 hover:text-gray-900 transition-colors">
+    <nav class="site-nav">
+        <div class="container nav-inner">
+            <a class="brand" href="#top" aria-label="Go to the top of the page">
+                <span class="brand-mark" aria-hidden="true">✂️</span>
+                <span>SnippingTool</span>
+            </a>
+            <div class="nav-links">
+                <a href="#features" class="nav-link">Features</a>
+                <a href="https://github.com/dimitar-radenkov/SnippingTool" target="_blank" rel="noopener noreferrer" class="github-link" aria-label="Open SnippingTool on GitHub">
                         <svg class="w-6 h-6" fill="currentColor" viewBox="0 0 24 24" aria-hidden="true">
                             <path fill-rule="evenodd" d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.504.337 1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" clip-rule="evenodd"></path>
                         </svg>
-                    </a>
-                </div>
+                </a>
             </div>
         </div>
     </nav>
 
     <!-- Hero Section -->
-    <main class="pt-20 pb-16 sm:pt-24 sm:pb-20 lg:pb-24">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-            <h1 class="text-5xl sm:text-6xl font-extrabold tracking-tight text-gray-900 mb-6">
+    <main id="top" class="hero">
+        <div class="container hero-panel">
+            <p class="hero-eyebrow">Built for tutorials, bug reports, and fast feedback</p>
+            <h1 class="hero-title">
                 Capture & Record like a <span class="gradient-text">Pro</span>
             </h1>
-            <p class="mt-4 text-xl text-gray-600 max-w-3xl mx-auto mb-10 leading-relaxed">
+            <p class="hero-copy">
                 A modern, lightning-fast screen capture and recording tool for Windows. Record your screen, add live annotations to explain your point, and redact sensitive data on the fly.
             </p>
             
-            <div class="flex flex-col sm:flex-row justify-center items-center gap-4 mb-16">
-                <a href="https://github.com/dimitar-radenkov/SnippingTool/releases/latest" class="inline-flex items-center justify-center px-8 py-4 text-base font-semibold text-white bg-blue-600 hover:bg-blue-700 rounded-lg shadow-lg hover:shadow-xl transition-all duration-200 transform hover:-translate-y-1 w-full sm:w-auto">
+            <div class="hero-actions">
+                <a href="https://github.com/dimitar-radenkov/SnippingTool/releases/latest" class="primary-button">
                     <svg class="w-5 h-5 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
                     Download for Windows
                 </a>
                 
-                <div class="bg-gray-100 border border-gray-200 rounded-lg px-6 py-4 flex items-center gap-3 w-full sm:w-auto shadow-inner group relative cursor-pointer" onclick="navigator.clipboard.writeText('winget install DimitarRadenkov.SnippingTool'); alert('Command copied to clipboard!');">
-                    <div class="font-mono text-sm text-gray-700">
-                        <span class="text-gray-400">$</span> winget install DimitarRadenkov.SnippingTool
-                    </div>
-                    <button class="text-gray-400 hover:text-blue-600 transition-colors" title="Copy command">
+                <button id="copy-command-button" type="button" class="command-button" aria-describedby="copy-command-status">
+                    <span class="command-content">
+                        <span class="command-text"><span class="command-prefix">$</span> winget install DimitarRadenkov.SnippingTool</span>
+                    </span>
+                    <span class="command-icon" aria-hidden="true">
                         <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
-                    </button>
-                    <!-- Tooltip -->
-                    <div class="absolute -top-10 left-1/2 transform -translate-x-1/2 bg-gray-800 text-white text-xs py-1 px-2 rounded opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none whitespace-nowrap">
-                        Click to copy
-                    </div>
-                </div>
+                    </span>
+                    <span class="command-tooltip">Copy command</span>
+                </button>
             </div>
+            <p id="copy-command-status" class="copy-status" role="status" aria-live="polite"></p>
 
             <!-- Video Demo -->
-            <div class="relative rounded-2xl overflow-hidden shadow-2xl border border-gray-200 bg-white max-w-5xl mx-auto transform hover:scale-[1.01] transition-transform duration-500">
-                <div class="absolute inset-0 bg-gradient-to-t from-gray-900/10 to-transparent pointer-events-none z-10"></div>
-                <video src="https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949" class="w-full h-auto" autoplay loop muted playsinline controls></video>
+            <div class="video-shell">
+                <div class="video-overlay"></div>
+                <video src="https://github.com/user-attachments/assets/d4e0c937-a845-4266-9454-2b816934f949" class="video-player" autoplay loop muted controls></video>
             </div>
         </div>
     </main>
 
     <!-- Features Section -->
-    <section id="features" class="py-20 bg-white border-t border-gray-100">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div class="text-center mb-16">
-                <h2 class="text-3xl font-bold text-gray-900 sm:text-4xl">Why use this over the built-in Windows tool?</h2>
-                <p class="mt-4 text-lg text-gray-600">Built for speed, privacy, and seamless communication.</p>
+    <section id="features" class="section">
+        <div class="container">
+            <div class="section-header">
+                <h2 class="section-title">Why use this over the built-in Windows tool?</h2>
+                <p class="section-copy">Built for speed, privacy, and seamless communication.</p>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-10">
+            <div class="feature-grid">
                 <!-- Feature 1 -->
-                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-blue-200 hover:shadow-md transition-all">
-                    <div class="w-12 h-12 bg-blue-100 text-blue-600 rounded-xl flex items-center justify-center mb-6">
+                <article class="feature-card">
+                    <div class="feature-icon blue">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">Live Video Annotations</h3>
-                    <p class="text-gray-600 leading-relaxed">Draw, highlight, and point things out <em>while</em> you are recording. No need for complicated post-production video editing to explain a bug or tutorial.</p>
-                </div>
+                    <h3 class="feature-title">Live Video Annotations</h3>
+                    <p class="feature-copy">Draw, highlight, and point things out <em>while</em> you are recording. No need for complicated post-production video editing to explain a bug or tutorial.</p>
+                </article>
 
                 <!-- Feature 2 -->
-                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-purple-200 hover:shadow-md transition-all">
-                    <div class="w-12 h-12 bg-purple-100 text-purple-600 rounded-xl flex items-center justify-center mb-6">
+                <article class="feature-card">
+                    <div class="feature-icon teal">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.875 18.825A10.05 10.05 0 0112 19c-4.478 0-8.268-2.943-9.543-7a9.97 9.97 0 011.563-3.029m5.858.908a3 3 0 114.243 4.243M9.878 9.878l4.242 4.242M9.88 9.88l-3.29-3.29m7.532 7.532l3.29 3.29M3 3l3.59 3.59m0 0A9.953 9.953 0 0112 5c4.478 0 8.268 2.943 9.543 7a10.025 10.025 0 01-4.132 5.411m0 0L21 21"></path></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">Privacy First (Live Blur)</h3>
-                    <p class="text-gray-600 leading-relaxed">Drag over sensitive content (passwords, emails, API keys) to apply a Gaussian blur instantly. It stays blurred even in your exported video recordings.</p>
-                </div>
+                    <h3 class="feature-title">Privacy First (Live Blur)</h3>
+                    <p class="feature-copy">Drag over sensitive content (passwords, emails, API keys) to apply a Gaussian blur instantly. It stays blurred even in your exported video recordings.</p>
+                </article>
 
                 <!-- Feature 3 -->
-                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-green-200 hover:shadow-md transition-all">
-                    <div class="w-12 h-12 bg-green-100 text-green-600 rounded-xl flex items-center justify-center mb-6">
+                <article class="feature-card">
+                    <div class="feature-icon green">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">Built-in OCR (Text Extraction)</h3>
-                    <p class="text-gray-600 leading-relaxed">Can't copy text from an image or video? Just lasso the text on your screen with SnippingTool, and it instantly extracts and copies it to your clipboard.</p>
-                </div>
+                    <h3 class="feature-title">Built-in OCR (Text Extraction)</h3>
+                    <p class="feature-copy">Can't copy text from an image or video? Just lasso the text on your screen with SnippingTool, and it instantly extracts and copies it to your clipboard.</p>
+                </article>
 
                 <!-- Feature 4 -->
-                <div class="bg-gray-50 rounded-2xl p-8 border border-gray-100 hover:border-orange-200 hover:shadow-md transition-all">
-                    <div class="w-12 h-12 bg-orange-100 text-orange-600 rounded-xl flex items-center justify-center mb-6">
+                <article class="feature-card">
+                    <div class="feature-icon orange">
                         <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z"></path></svg>
                     </div>
-                    <h3 class="text-xl font-bold text-gray-900 mb-3">Pin to Screen</h3>
-                    <p class="text-gray-600 leading-relaxed">Working on something complex? Pin a captured screenshot as a floating, always-on-top window for quick reference while you code or type.</p>
-                </div>
+                    <h3 class="feature-title">Pin to Screen</h3>
+                    <p class="feature-copy">Working on something complex? Pin a captured screenshot as a floating, always-on-top window for quick reference while you code or type.</p>
+                </article>
             </div>
         </div>
     </section>
 
     <!-- Footer -->
-    <footer class="bg-gray-900 text-white py-12">
-        <div class="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 flex flex-col md:flex-row justify-between items-center gap-6">
-            <div class="flex items-center gap-2">
-                <span class="text-2xl">✂️</span>
-                <span class="font-bold text-xl tracking-tight">SnippingTool</span>
+    <footer class="footer">
+        <div class="container footer-inner">
+            <div class="brand">
+                <span class="brand-mark" aria-hidden="true">✂️</span>
+                <span>SnippingTool</span>
             </div>
             
-            <div class="flex space-x-6 text-sm text-gray-400 text-center md:text-left">
+            <div class="footer-links">
                 <span>Built on .NET 10, WPF, and MVVM</span>
                 <a href="https://github.com/dimitar-radenkov/SnippingTool/issues" class="hover:text-white transition-colors">Report an Issue</a>
                 <a href="https://github.com/dimitar-radenkov/SnippingTool" class="hover:text-white transition-colors">Source Code</a>
             </div>
         </div>
     </footer>
+
+    <script>
+        (() => {
+            const copyButton = document.getElementById("copy-command-button");
+            const copyStatus = document.getElementById("copy-command-status");
+            const command = "winget install DimitarRadenkov.SnippingTool";
+
+            if (!(copyButton instanceof HTMLButtonElement) || !(copyStatus instanceof HTMLElement)) {
+                return;
+            }
+
+            const setStatus = (message, kind) => {
+                copyStatus.textContent = message;
+                copyStatus.className = kind ? `copy-status is-${kind}` : "copy-status";
+            };
+
+            const fallbackCopy = (text) => {
+                const textArea = document.createElement("textarea");
+                textArea.value = text;
+                textArea.setAttribute("readonly", "readonly");
+                textArea.style.position = "fixed";
+                textArea.style.opacity = "0";
+                document.body.appendChild(textArea);
+                textArea.select();
+
+                const didCopy = document.execCommand("copy");
+                document.body.removeChild(textArea);
+
+                if (!didCopy) {
+                    throw new Error("Fallback copy failed.");
+                }
+            };
+
+            copyButton.addEventListener("click", async () => {
+                copyButton.disabled = true;
+                setStatus("Copying command...", "");
+
+                try {
+                    if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+                        await navigator.clipboard.writeText(command);
+                    }
+                    else {
+                        fallbackCopy(command);
+                    }
+
+                    setStatus("Command copied to clipboard.", "success");
+                }
+                catch (error) {
+                    try {
+                        fallbackCopy(command);
+                        setStatus("Command copied to clipboard.", "success");
+                    }
+                    catch {
+                        setStatus("Could not copy automatically. Please copy the command manually.", "error");
+                    }
+                }
+                finally {
+                    window.setTimeout(() => {
+                        copyButton.disabled = false;
+                    }, 300);
+                }
+            });
+        })();
+    </script>
 
 </body>
 </html>

--- a/website/robots.txt
+++ b/website/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://dimitar-radenkov.github.io/SnippingTool/sitemap.xml

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://dimitar-radenkov.github.io/SnippingTool/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/website/styles.css
+++ b/website/styles.css
@@ -330,6 +330,10 @@ button {
     background: rgba(255, 255, 255, 0.72);
 }
 
+.section-alt {
+    background: linear-gradient(180deg, rgba(230, 240, 252, 0.58) 0%, rgba(255, 255, 255, 0.86) 100%);
+}
+
 .section-header {
     max-width: 680px;
     margin: 0 auto 48px;
@@ -352,6 +356,49 @@ button {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 24px;
+}
+
+.comparison-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 24px;
+    margin-bottom: 28px;
+}
+
+.comparison-card {
+    padding: 28px;
+    border: 1px solid rgba(215, 225, 236, 0.92);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: var(--shadow-soft);
+}
+
+.comparison-title {
+    margin: 0 0 12px;
+    font-size: 1.2rem;
+    letter-spacing: -0.03em;
+}
+
+.comparison-copy {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
+.seo-copy-block {
+    max-width: 920px;
+    margin: 0 auto;
+    color: var(--muted);
+    font-size: 1.05rem;
+    line-height: 1.8;
+}
+
+.seo-copy-block p {
+    margin: 0 0 16px;
+}
+
+.seo-copy-block p:last-child {
+    margin-bottom: 0;
 }
 
 .feature-card {
@@ -437,7 +484,8 @@ button {
 }
 
 @media (max-width: 900px) {
-    .feature-grid {
+    .feature-grid,
+    .comparison-grid {
         grid-template-columns: 1fr;
     }
 }

--- a/website/styles.css
+++ b/website/styles.css
@@ -1,0 +1,467 @@
+:root {
+    --background: #f3f7fb;
+    --background-accent: #e4eefc;
+    --surface: rgba(255, 255, 255, 0.84);
+    --surface-strong: #ffffff;
+    --text: #132031;
+    --muted: #576579;
+    --line: #d7e1ec;
+    --shadow: 0 24px 60px rgba(19, 32, 49, 0.12);
+    --shadow-soft: 0 12px 30px rgba(19, 32, 49, 0.08);
+    --accent: #0f62fe;
+    --accent-strong: #0a4fd1;
+    --accent-soft: #deebff;
+    --success: #087443;
+    --success-soft: #dcfce7;
+    --error: #b42318;
+    --error-soft: #fee4e2;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    color: var(--text);
+    font-family: Bahnschrift, "Aptos", "Segoe UI", sans-serif;
+    background:
+        radial-gradient(circle at top left, rgba(15, 98, 254, 0.12), transparent 28%),
+        radial-gradient(circle at top right, rgba(0, 183, 195, 0.12), transparent 24%),
+        linear-gradient(180deg, var(--background-accent) 0%, var(--background) 20%, #f8fbfe 100%);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+button {
+    font: inherit;
+}
+
+.container {
+    width: min(1120px, calc(100% - 32px));
+    margin: 0 auto;
+}
+
+.site-nav {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    border-bottom: 1px solid rgba(215, 225, 236, 0.9);
+    background: rgba(255, 255, 255, 0.78);
+    -webkit-backdrop-filter: blur(16px);
+    backdrop-filter: blur(16px);
+}
+
+.nav-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    min-height: 72px;
+}
+
+.brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 1.25rem;
+    font-weight: 700;
+    letter-spacing: -0.03em;
+}
+
+.brand-mark {
+    font-size: 1.65rem;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 18px;
+}
+
+.nav-link {
+    color: var(--muted);
+    font-weight: 600;
+    transition: color 0.2s ease;
+}
+
+.nav-link:hover,
+.nav-link:focus-visible {
+    color: var(--accent);
+}
+
+.github-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: 1px solid var(--line);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: var(--shadow-soft);
+    color: var(--muted);
+    transition:
+        transform 0.2s ease,
+        color 0.2s ease,
+        border-color 0.2s ease;
+}
+
+.github-link:hover,
+.github-link:focus-visible {
+    transform: translateY(-1px);
+    color: var(--text);
+    border-color: rgba(15, 98, 254, 0.35);
+}
+
+.hero {
+    padding: 84px 0 72px;
+}
+
+.hero-panel {
+    text-align: center;
+}
+
+.hero-eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 14px;
+    border: 1px solid rgba(15, 98, 254, 0.18);
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.74);
+    color: var(--muted);
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.hero-title {
+    margin: 22px auto 20px;
+    max-width: 860px;
+    font-size: clamp(3rem, 5vw, 5rem);
+    line-height: 0.95;
+    letter-spacing: -0.06em;
+}
+
+.gradient-text {
+    background: linear-gradient(120deg, #0f62fe 0%, #0aa6c2 100%);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+}
+
+.hero-copy {
+    margin: 0 auto 32px;
+    max-width: 760px;
+    color: var(--muted);
+    font-size: clamp(1.1rem, 2vw, 1.3rem);
+    line-height: 1.7;
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: stretch;
+    gap: 16px;
+    margin-bottom: 12px;
+}
+
+.primary-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 12px;
+    min-height: 62px;
+    padding: 0 28px;
+    border-radius: 18px;
+    background: linear-gradient(135deg, var(--accent) 0%, #2f83ff 100%);
+    color: #ffffff;
+    font-weight: 700;
+    box-shadow: 0 18px 32px rgba(15, 98, 254, 0.24);
+    transition:
+        transform 0.2s ease,
+        box-shadow 0.2s ease,
+        background 0.2s ease;
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 38px rgba(15, 98, 254, 0.28);
+    background: linear-gradient(135deg, var(--accent-strong) 0%, #226fe3 100%);
+}
+
+.command-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 18px;
+    min-height: 62px;
+    max-width: 100%;
+    padding: 0 20px;
+    border: 1px solid var(--line);
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.9);
+    color: var(--text);
+    cursor: pointer;
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.8),
+        var(--shadow-soft);
+    transition:
+        transform 0.2s ease,
+        border-color 0.2s ease,
+        box-shadow 0.2s ease;
+}
+
+.command-button:hover,
+.command-button:focus-visible {
+    transform: translateY(-2px);
+    border-color: rgba(15, 98, 254, 0.35);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.8),
+        0 18px 34px rgba(19, 32, 49, 0.12);
+}
+
+.command-button:disabled {
+    cursor: progress;
+    opacity: 0.86;
+}
+
+.command-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+}
+
+.command-text {
+    min-width: 0;
+    overflow-wrap: anywhere;
+    text-align: left;
+    color: #29384a;
+    font-family: Consolas, "Cascadia Code", monospace;
+    font-size: 0.95rem;
+}
+
+.command-prefix {
+    color: #7b8794;
+}
+
+.command-icon {
+    flex-shrink: 0;
+    color: #6f7a88;
+}
+
+.command-tooltip {
+    position: absolute;
+    top: -42px;
+    left: 50%;
+    transform: translateX(-50%);
+    padding: 6px 10px;
+    border-radius: 999px;
+    background: #132031;
+    color: #ffffff;
+    font-size: 0.78rem;
+    font-weight: 600;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.command-button:hover .command-tooltip,
+.command-button:focus-visible .command-tooltip {
+    opacity: 1;
+}
+
+.copy-status {
+    min-height: 24px;
+    margin: 0 0 48px;
+    color: var(--muted);
+    font-size: 0.95rem;
+    font-weight: 600;
+}
+
+.copy-status.is-success {
+    color: var(--success);
+}
+
+.copy-status.is-error {
+    color: var(--error);
+}
+
+.video-shell {
+    position: relative;
+    overflow: hidden;
+    max-width: 1040px;
+    margin: 0 auto;
+    border: 1px solid rgba(215, 225, 236, 0.9);
+    border-radius: 28px;
+    background: var(--surface-strong);
+    box-shadow: var(--shadow);
+}
+
+.video-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(180deg, transparent 0%, rgba(19, 32, 49, 0.1) 100%);
+}
+
+.video-player {
+    display: block;
+    width: 100%;
+    height: auto;
+}
+
+.section {
+    padding: 84px 0;
+    border-top: 1px solid rgba(215, 225, 236, 0.9);
+    background: rgba(255, 255, 255, 0.72);
+}
+
+.section-header {
+    max-width: 680px;
+    margin: 0 auto 48px;
+    text-align: center;
+}
+
+.section-title {
+    margin: 0 0 14px;
+    font-size: clamp(2rem, 3vw, 2.8rem);
+    letter-spacing: -0.04em;
+}
+
+.section-copy {
+    margin: 0;
+    color: var(--muted);
+    font-size: 1.1rem;
+}
+
+.feature-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 24px;
+}
+
+.feature-card {
+    padding: 32px;
+    border: 1px solid rgba(215, 225, 236, 0.92);
+    border-radius: 24px;
+    background: rgba(255, 255, 255, 0.92);
+    box-shadow: var(--shadow-soft);
+}
+
+.feature-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 52px;
+    height: 52px;
+    border-radius: 16px;
+    margin-bottom: 22px;
+}
+
+.feature-icon.blue {
+    background: #dce9ff;
+    color: #0f62fe;
+}
+
+.feature-icon.teal {
+    background: #daf5f8;
+    color: #0b90a5;
+}
+
+.feature-icon.green {
+    background: #dcfce7;
+    color: #087443;
+}
+
+.feature-icon.orange {
+    background: #ffead5;
+    color: #c2410c;
+}
+
+.feature-title {
+    margin: 0 0 12px;
+    font-size: 1.35rem;
+    letter-spacing: -0.03em;
+}
+
+.feature-copy {
+    margin: 0;
+    color: var(--muted);
+    line-height: 1.7;
+}
+
+.footer {
+    padding: 40px 0;
+    background: #132031;
+    color: #f3f7fb;
+}
+
+.footer-inner {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 20px;
+    flex-wrap: wrap;
+}
+
+.footer-links {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px 24px;
+    justify-content: center;
+    color: #c8d3e0;
+    font-size: 0.95rem;
+}
+
+.footer-links a {
+    transition: color 0.2s ease;
+}
+
+.footer-links a:hover,
+.footer-links a:focus-visible {
+    color: #ffffff;
+}
+
+@media (max-width: 900px) {
+    .feature-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+@media (max-width: 720px) {
+    .hero {
+        padding-top: 56px;
+    }
+
+    .nav-link {
+        display: none;
+    }
+
+    .command-button,
+    .primary-button {
+        width: 100%;
+    }
+
+    .copy-status {
+        margin-bottom: 36px;
+    }
+
+    .footer-inner {
+        justify-content: center;
+        text-align: center;
+    }
+}


### PR DESCRIPTION
This PR adds the `/website` folder containing a dedicated HTML landing page and configures a GitHub Actions workflow to automatically publish the site on GitHub Pages. This separates the public-facing landing page from internal documentation, improving discoverability and downloads.