### PR TITLE
feat: add audience growth improvements

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+custom:
+  - https://paypal.me/DimitarRadenkov
+  - https://revolut.me/dimitarradenkov

--- a/.gitignore
+++ b/.gitignore
@@ -372,3 +372,4 @@ MigrationBackup/
 
 # ffmpeg binary — downloaded by developer locally, not committed
 /Pointframe/Assets/ffmpeg/ffmpeg.exe
+.playwright-mcp/

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ winget install DimitarRadenkov.Pointframe
 2. Press `Print Screen` to open the capture overlay and select the region you want.
 3. Annotate, copy, save, pin, or record the region from the overlay and recording HUD.
 
+If you find Pointframe useful, a ⭐ on GitHub helps others discover it — thank you!
+
 ## ✨ Why use this over the built-in Windows tool?
 
 - **Live Video Annotations:** Draw, highlight, and redact *while* recording. No need for post-production video editing.

--- a/website/blur-screen-recording-windows.html
+++ b/website/blur-screen-recording-windows.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>How to Blur a Screen Recording on Windows | Pointframe</title>
+    <meta name="description" content="Need to blur sensitive content in a screen recording on Windows? Pointframe lets you apply live blur while recording — no post-editing required.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://dimitar-radenkov.github.io/Pointframe/blur-screen-recording-windows.html">
+    <link rel="icon" href="./favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="./app-icon.png">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="How to Blur a Screen Recording on Windows | Pointframe">
+    <meta property="og:description" content="Apply live blur to sensitive content while recording your screen on Windows. No video editor needed.">
+    <meta property="og:url" content="https://dimitar-radenkov.github.io/Pointframe/blur-screen-recording-windows.html">
+    <meta property="og:site_name" content="Pointframe">
+    <meta property="og:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="How to Blur a Screen Recording on Windows | Pointframe">
+    <meta name="twitter:description" content="Blur passwords, emails, and sensitive data live while screen recording on Windows — no post-editing required.">
+    <meta name="twitter:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta name="twitter:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <link rel="stylesheet" href="./styles.css">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "HowTo",
+            "name": "How to blur sensitive content in a screen recording on Windows",
+            "description": "Apply a live Gaussian blur to passwords, emails, and private data while recording your screen on Windows using Pointframe.",
+            "step": [
+                {
+                    "@type": "HowToStep",
+                    "name": "Start a screen recording",
+                    "text": "Press the capture hotkey, select the region you want to record, then click the Record button in the overlay toolbar."
+                },
+                {
+                    "@type": "HowToStep",
+                    "name": "Switch to the Blur tool",
+                    "text": "From the recording HUD, select the Blur annotation tool."
+                },
+                {
+                    "@type": "HowToStep",
+                    "name": "Draw over the sensitive content",
+                    "text": "Drag a blur rectangle over passwords, emails, API keys, or any private data. The blur is applied live and samples from the actual recording region."
+                },
+                {
+                    "@type": "HowToStep",
+                    "name": "Stop and export",
+                    "text": "Stop the recording from the HUD. The blurred regions are baked into the exported MP4 — no video editor needed."
+                }
+            ],
+            "url": "https://dimitar-radenkov.github.io/Pointframe/blur-screen-recording-windows.html"
+        }
+    </script>
+</head>
+<body>
+    <nav class="site-nav">
+        <div class="container nav-inner">
+            <a class="brand" href="./index.html" aria-label="Go to the Pointframe homepage">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </a>
+            <div class="nav-links">
+                <a href="./index.html#compare" class="nav-link">Compare</a>
+                <a href="./index.html#resources" class="nav-link">Guides</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="nav-link">Download</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="hero article-hero">
+        <div class="container hero-panel">
+            <p class="hero-eyebrow">Live blur for screen recordings on Windows</p>
+            <h1 class="hero-title article-title">How to Blur a Screen Recording on Windows</h1>
+            <p class="hero-copy">Most screen recording tools require you to blur sensitive content in a video editor after the fact. Pointframe lets you draw blur annotations live while you record — the redaction is baked into the exported video with no post-processing needed.</p>
+            <div class="hero-actions">
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Download for Windows</a>
+                <a href="./index.html#features" class="secondary-link">See all features</a>
+            </div>
+        </div>
+    </main>
+
+    <section class="section section-alt">
+        <div class="container">
+            <div class="content-shell">
+                <article class="content-card">
+                    <h2>The problem with blurring recordings after the fact</h2>
+                    <p>Standard workflows for blurring screen recordings involve opening the exported video in an editor, adding a blur or mosaic effect to a region, and then re-exporting. This takes time, requires video editing knowledge, and risks introducing compression artefacts. If you need to blur a dynamic area — like a browser address bar that scrolls — tracking it frame by frame becomes a significant effort.</p>
+
+                    <h2>How live blur works in Pointframe</h2>
+                    <p>When you select the Blur tool during a recording session, you drag a rectangle over the content you want to hide. Pointframe applies a Gaussian blur that samples directly from the live capture region. The blurred content appears blurred in the final exported MP4 from the moment you placed the annotation — no editor, no tracking, no re-export.</p>
+
+                    <h2>Step-by-step: blurring during a screen recording</h2>
+                    <ol>
+                        <li>Press your capture hotkey (default: <kbd>Print Screen</kbd>) and draw a selection around the area you want to record.</li>
+                        <li>Click the <strong>Record</strong> button in the overlay toolbar to start recording.</li>
+                        <li>When you need to hide sensitive content, select the <strong>Blur</strong> tool from the recording HUD.</li>
+                        <li>Drag a blur rectangle over the content — a password field, an email address, an API key, or any private data.</li>
+                        <li>Stop the recording from the HUD when you are done.</li>
+                        <li>The exported MP4 has the blur baked in. No video editor required.</li>
+                    </ol>
+
+                    <h2>Common use cases</h2>
+                    <ul>
+                        <li>Recording a product demo that shows authenticated screens</li>
+                        <li>Making a support video that involves your email or account details</li>
+                        <li>Sharing a development walkthrough that includes API keys or tokens in an IDE</li>
+                        <li>Recording a tutorial on a shared machine with personal notifications visible</li>
+                    </ul>
+
+                    <h2>Blur also works on screenshots</h2>
+                    <p>The same blur tool is available in the screenshot annotation overlay. Select a region, annotate with blur, copy or save — the exported image has the blur baked in from the start.</p>
+
+                    <div class="cta-panel">
+                        <h3>Blur sensitive content without a video editor</h3>
+                        <p>Pointframe is free, open-source, and ships as a signed Windows installer. No account or subscription required.</p>
+                        <div class="hero-actions compact-actions">
+                            <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Get Pointframe Free</a>
+                            <a href="./screen-recorder-with-annotations-windows.html" class="secondary-link">See the full recording workflow</a>
+                        </div>
+                    </div>
+                </article>
+
+                <div class="related-links-block">
+                    <h2 class="related-heading">Related pages</h2>
+                    <div class="resource-grid compact-grid">
+                        <a href="./screen-recorder-with-annotations-windows.html" class="resource-card">
+                            <h3 class="resource-title">Screen recorder with annotations</h3>
+                            <p class="resource-copy">Draw, highlight, and point things out while recording — no post-editing needed.</p>
+                        </a>
+                        <a href="./copy-text-from-screenshot-windows.html" class="resource-card">
+                            <h3 class="resource-title">Copy text from a screenshot</h3>
+                            <p class="resource-copy">Use OCR to extract text from screenshots and images on Windows.</p>
+                        </a>
+                        <a href="./free-snagit-alternative-windows.html" class="resource-card">
+                            <h3 class="resource-title">Free Snagit alternative</h3>
+                            <p class="resource-copy">See how Pointframe compares with Snagit for everyday capture workflows.</p>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container footer-inner">
+            <div class="brand">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </div>
+            <div class="footer-links">
+                <a href="./index.html">Home</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe">GitHub</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest">Download</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/website/free-snagit-alternative-windows.html
+++ b/website/free-snagit-alternative-windows.html
@@ -1,0 +1,141 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Free Snagit Alternative for Windows | Pointframe</title>
+    <meta name="description" content="Looking for a free Snagit alternative on Windows? Pointframe gives you screen capture, live recording annotations, blur redaction, and OCR — for free.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://dimitar-radenkov.github.io/Pointframe/free-snagit-alternative-windows.html">
+    <link rel="icon" href="./favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="./app-icon.png">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Free Snagit Alternative for Windows | Pointframe">
+    <meta property="og:description" content="Replace Snagit with a free Windows screen capture and recording tool that includes live annotations, blur, and OCR.">
+    <meta property="og:url" content="https://dimitar-radenkov.github.io/Pointframe/free-snagit-alternative-windows.html">
+    <meta property="og:site_name" content="Pointframe">
+    <meta property="og:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Free Snagit Alternative for Windows | Pointframe">
+    <meta name="twitter:description" content="A free Windows screen capture tool with live annotations, blur, and OCR — a practical alternative to Snagit.">
+    <meta name="twitter:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta name="twitter:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <link rel="stylesheet" href="./styles.css">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "Free Snagit Alternative for Windows",
+            "description": "How to replace Snagit with a free Windows screen capture and recording tool that includes live annotations, blur redaction, and OCR.",
+            "url": "https://dimitar-radenkov.github.io/Pointframe/free-snagit-alternative-windows.html",
+            "author": {
+                "@type": "Person",
+                "name": "Dimitar Radenkov"
+            },
+            "publisher": {
+                "@type": "Organization",
+                "name": "Pointframe"
+            }
+        }
+    </script>
+</head>
+<body>
+    <nav class="site-nav">
+        <div class="container nav-inner">
+            <a class="brand" href="./index.html" aria-label="Go to the Pointframe homepage">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </a>
+            <div class="nav-links">
+                <a href="./index.html#compare" class="nav-link">Compare</a>
+                <a href="./index.html#resources" class="nav-link">Guides</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="nav-link">Download</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="hero article-hero">
+        <div class="container hero-panel">
+            <p class="hero-eyebrow">Free alternative to Snagit on Windows</p>
+            <h1 class="hero-title article-title">A Free Snagit Alternative for Windows</h1>
+            <p class="hero-copy">Snagit is excellent, but its annual licence cost adds up. Pointframe is a free, open-source Windows screen capture and recording tool that covers the core workflows most Snagit users actually rely on — without the subscription.</p>
+            <div class="hero-actions">
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Download for Windows</a>
+                <a href="./index.html#compare" class="secondary-link">See the full comparison</a>
+            </div>
+        </div>
+    </main>
+
+    <section class="section section-alt">
+        <div class="container">
+            <div class="content-shell">
+                <article class="content-card">
+                    <h2>What Snagit users rely on most</h2>
+                    <p>Snagit built its reputation on three things: fast region capture, quick markup tools, and the ability to produce a shareable asset — screenshot or video — without opening a separate editor. Most users do not use 80% of Snagit's feature set. They just want a reliable capture, an arrow or two, maybe a blur over a password, and then copy or save.</p>
+
+                    <h2>How Pointframe covers those workflows</h2>
+                    <ul>
+                        <li><strong>Region capture</strong> — press the configured hotkey, draw a selection, and the screen freezes so you can capture menus and tooltips exactly as they appear</li>
+                        <li><strong>Annotation tools</strong> — arrows, rectangles, circles, highlighted text, numbered steps, pen, and a callout speech bubble</li>
+                        <li><strong>Blur redaction</strong> — drag a blur annotation over passwords, emails, or any sensitive content before saving or sharing</li>
+                        <li><strong>OCR</strong> — lasso text in a screenshot to copy it straight to your clipboard without retyping</li>
+                        <li><strong>Screen recording with live annotations</strong> — draw, highlight, and point things out while the recording is in progress, no post-editing required</li>
+                        <li><strong>MP4 and GIF export</strong> — produce standard video files that embed cleanly in Jira, GitHub, Slack, or documentation</li>
+                        <li><strong>Auto-updates</strong> — Pointframe checks for new releases in the background and installs them without opening a browser</li>
+                    </ul>
+
+                    <h2>What Snagit has that Pointframe does not</h2>
+                    <p>Snagit includes a full-screen scrolling capture, a dedicated image library, and a rich post-capture editor with templates. If those features are central to your daily workflow, Snagit may still be the right tool. But if your main use is quick capture, fast markup, and sharing — Pointframe does that well and costs nothing.</p>
+
+                    <h2>Getting started</h2>
+                    <p>Install via winget or download the installer from the releases page. The default hotkey is <kbd>Print Screen</kbd>, which you can change in Settings. Pointframe lives in the system tray and stays out of your way until you need it.</p>
+
+                    <div class="cta-panel">
+                        <h3>Try a free Snagit alternative</h3>
+                        <p>Pointframe is open-source, free, and ships as a signed Windows installer. No account, no subscription, no telemetry.</p>
+                        <div class="hero-actions compact-actions">
+                            <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Get Pointframe Free</a>
+                            <a href="./screen-recorder-with-annotations-windows.html" class="secondary-link">See the recording workflow</a>
+                        </div>
+                    </div>
+                </article>
+
+                <div class="related-links-block">
+                    <h2 class="related-heading">Related pages</h2>
+                    <div class="resource-grid compact-grid">
+                        <a href="./screen-recorder-with-annotations-windows.html" class="resource-card">
+                            <h3 class="resource-title">Screen recorder with annotations</h3>
+                            <p class="resource-copy">Record your screen with live drawing and blur — no post-editing needed.</p>
+                        </a>
+                        <a href="./windows-snipping-tool-alternative.html" class="resource-card">
+                            <h3 class="resource-title">Windows Snipping Tool alternative</h3>
+                            <p class="resource-copy">See how Pointframe compares with the built-in Windows screenshot tool.</p>
+                        </a>
+                        <a href="./copy-text-from-screenshot-windows.html" class="resource-card">
+                            <h3 class="resource-title">Copy text from a screenshot</h3>
+                            <p class="resource-copy">Use OCR to extract text from screenshots and images on Windows.</p>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container footer-inner">
+            <div class="brand">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </div>
+            <div class="footer-links">
+                <a href="./index.html">Home</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe">GitHub</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest">Download</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/website/index.html
+++ b/website/index.html
@@ -238,6 +238,18 @@
                     <h3 class="resource-title">How to copy text from a screenshot on Windows</h3>
                     <p class="resource-copy">An OCR-focused page for the high-intent search query around extracting text from screenshots and images.</p>
                 </a>
+                <a href="./free-snagit-alternative-windows.html" class="resource-card">
+                    <h3 class="resource-title">Free Snagit alternative for Windows</h3>
+                    <p class="resource-copy">How Pointframe covers the core Snagit workflows — capture, markup, blur, recording — for free.</p>
+                </a>
+                <a href="./blur-screen-recording-windows.html" class="resource-card">
+                    <h3 class="resource-title">How to blur a screen recording on Windows</h3>
+                    <p class="resource-copy">Apply live blur to passwords and sensitive content while recording — no video editor needed.</p>
+                </a>
+                <a href="./screen-capture-bug-reports.html" class="resource-card">
+                    <h3 class="resource-title">Screen capture tool for bug reports</h3>
+                    <p class="resource-copy">Capture, annotate with numbered steps, and attach evidence to tickets without leaving your workflow.</p>
+                </a>
             </div>
         </div>
     </section>

--- a/website/screen-capture-bug-reports.html
+++ b/website/screen-capture-bug-reports.html
@@ -1,0 +1,147 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Best Screen Capture Tool for Bug Reports | Pointframe</title>
+    <meta name="description" content="Speed up bug reports with a screen capture tool built for developers and QA. Annotate, blur, and record exactly what matters — without a separate editor.">
+    <meta name="robots" content="index, follow">
+    <link rel="canonical" href="https://dimitar-radenkov.github.io/Pointframe/screen-capture-bug-reports.html">
+    <link rel="icon" href="./favicon.ico" sizes="any">
+    <link rel="apple-touch-icon" href="./app-icon.png">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="Best Screen Capture Tool for Bug Reports | Pointframe">
+    <meta property="og:description" content="Annotate, blur, and record exactly what matters for bug reports — without a separate editor.">
+    <meta property="og:url" content="https://dimitar-radenkov.github.io/Pointframe/screen-capture-bug-reports.html">
+    <meta property="og:site_name" content="Pointframe">
+    <meta property="og:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta property="og:image:width" content="1200">
+    <meta property="og:image:height" content="630">
+    <meta property="og:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="Best Screen Capture Tool for Bug Reports | Pointframe">
+    <meta name="twitter:description" content="Capture, annotate, and share bug evidence fast. A screen capture workflow built for developers and QA.">
+    <meta name="twitter:image" content="https://dimitar-radenkov.github.io/Pointframe/social-preview.png">
+    <meta name="twitter:image:alt" content="Pointframe social preview showing screen capture, recording, and OCR workflow highlights.">
+    <link rel="stylesheet" href="./styles.css">
+    <script type="application/ld+json">
+        {
+            "@context": "https://schema.org",
+            "@type": "TechArticle",
+            "headline": "Best Screen Capture Tool for Bug Reports",
+            "description": "How to speed up bug reporting with a screen capture tool that includes live annotations, blur redaction, region recording, and OCR.",
+            "url": "https://dimitar-radenkov.github.io/Pointframe/screen-capture-bug-reports.html",
+            "author": {
+                "@type": "Person",
+                "name": "Dimitar Radenkov"
+            },
+            "publisher": {
+                "@type": "Organization",
+                "name": "Pointframe"
+            }
+        }
+    </script>
+</head>
+<body>
+    <nav class="site-nav">
+        <div class="container nav-inner">
+            <a class="brand" href="./index.html" aria-label="Go to the Pointframe homepage">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </a>
+            <div class="nav-links">
+                <a href="./index.html#compare" class="nav-link">Compare</a>
+                <a href="./index.html#resources" class="nav-link">Guides</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="nav-link">Download</a>
+            </div>
+        </div>
+    </nav>
+
+    <main class="hero article-hero">
+        <div class="container hero-panel">
+            <p class="hero-eyebrow">Screen capture for developers and QA teams</p>
+            <h1 class="hero-title article-title">The Screen Capture Tool Built for Bug Reports</h1>
+            <p class="hero-copy">A good bug report shows the problem — it does not just describe it. Pointframe is designed around this idea: capture the region, annotate the issue, blur what should stay private, and attach the result to your ticket in seconds.</p>
+            <div class="hero-actions">
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Download for Windows</a>
+                <a href="./index.html#features" class="secondary-link">See all features</a>
+            </div>
+        </div>
+    </main>
+
+    <section class="section section-alt">
+        <div class="container">
+            <div class="content-shell">
+                <article class="content-card">
+                    <h2>What makes a screenshot useful in a bug report</h2>
+                    <p>A raw screenshot often leaves the reviewer guessing. They see the screen but not the specific element, state, or sequence that caused the issue. The tools that produce useful bug evidence share the same pattern: capture the right region at the right moment, add visual callouts that point directly at the problem, and deliver the result without friction.</p>
+
+                    <h2>How Pointframe fits a bug reporting workflow</h2>
+                    <ul>
+                        <li><strong>Frozen snapshot capture</strong> — the screen freezes the instant you press the hotkey, so you can capture dropdown states, tooltips, hover effects, and loading states exactly as they appeared</li>
+                        <li><strong>Numbered steps</strong> — annotate a sequence of actions with numbered circular badges so reviewers follow the reproduction steps at a glance</li>
+                        <li><strong>Arrows and callouts</strong> — point directly at the broken element; add a speech-bubble callout to describe the expected versus actual behaviour</li>
+                        <li><strong>Blur</strong> — hide credentials, personal data, or unrelated content before attaching to a public ticket or shared workspace</li>
+                        <li><strong>Region recording</strong> — record a short clip to demonstrate the bug in motion; live annotations let you draw attention to the exact frame where the issue occurs</li>
+                        <li><strong>MP4 and GIF export</strong> — both formats embed natively in GitHub issues, Jira, Linear, Notion, and Slack without needing a link to an external host</li>
+                        <li><strong>Copy to clipboard</strong> — paste a screenshot directly into a browser or Jira field with a single shortcut</li>
+                    </ul>
+
+                    <h2>A typical bug reporting session</h2>
+                    <ol>
+                        <li>Reproduce the bug and freeze the screen state with the capture hotkey.</li>
+                        <li>Draw an arrow to the broken element and add a numbered step or callout text.</li>
+                        <li>If the token or email in the screenshot should stay private, add a blur annotation.</li>
+                        <li>Press <kbd>Ctrl+C</kbd> to copy to clipboard and paste directly into the issue tracker, or save to file and attach.</li>
+                        <li>If the bug is best shown in motion, use the recording workflow and export as GIF or MP4.</li>
+                    </ol>
+
+                    <h2>Why developers adopt Pointframe for this</h2>
+                    <p>The workflow maps to keyboard shortcuts and a system tray presence that stays out of the way. There is no application to switch to, no library to open, and no cloud upload required. The output lands on the clipboard or a local folder immediately, which is exactly the friction point most screen capture tools introduce.</p>
+
+                    <div class="cta-panel">
+                        <h3>Show the bug, not just describe it</h3>
+                        <p>Pointframe is free, open-source, and ships as a signed Windows installer. No account or subscription required.</p>
+                        <div class="hero-actions compact-actions">
+                            <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest" class="primary-button">Get Pointframe Free</a>
+                            <a href="./screen-recorder-with-annotations-windows.html" class="secondary-link">See the recording workflow</a>
+                        </div>
+                    </div>
+                </article>
+
+                <div class="related-links-block">
+                    <h2 class="related-heading">Related pages</h2>
+                    <div class="resource-grid compact-grid">
+                        <a href="./screen-recorder-with-annotations-windows.html" class="resource-card">
+                            <h3 class="resource-title">Screen recorder with annotations</h3>
+                            <p class="resource-copy">Record bugs in motion with live drawing and callouts.</p>
+                        </a>
+                        <a href="./blur-screen-recording-windows.html" class="resource-card">
+                            <h3 class="resource-title">Blur sensitive content in recordings</h3>
+                            <p class="resource-copy">Hide passwords and private data before sharing any recording.</p>
+                        </a>
+                        <a href="./copy-text-from-screenshot-windows.html" class="resource-card">
+                            <h3 class="resource-title">Copy text from a screenshot</h3>
+                            <p class="resource-copy">Extract error messages and stack traces from screenshots using OCR.</p>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <footer class="footer">
+        <div class="container footer-inner">
+            <div class="brand">
+                <img src="./app-icon.png" alt="" class="brand-logo" width="32" height="32">
+                <span>Pointframe</span>
+            </div>
+            <div class="footer-links">
+                <a href="./index.html">Home</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe">GitHub</a>
+                <a href="https://github.com/dimitar-radenkov/Pointframe/releases/latest">Download</a>
+            </div>
+        </div>
+    </footer>
+</body>
+</html>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -24,4 +24,22 @@
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
+  <url>
+    <loc>https://dimitar-radenkov.github.io/Pointframe/free-snagit-alternative-windows.html</loc>
+    <lastmod>2026-04-28T00:00:00Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dimitar-radenkov.github.io/Pointframe/blur-screen-recording-windows.html</loc>
+    <lastmod>2026-04-28T00:00:00Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://dimitar-radenkov.github.io/Pointframe/screen-capture-bug-reports.html</loc>
+    <lastmod>2026-04-28T00:00:00Z</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
- Add GitHub repo topics for discoverability (screenshot, screen-recording, windows, wpf, ocr, etc.)
- Add .github/FUNDING.yml to enable Sponsor button (PayPal + Revolut)
- Add star CTA nudge to README
- Add 3 new SEO landing pages: free Snagit alternative, blur screen recording, screen capture for bug reports
- Update sitemap.xml with new pages
- Update homepage resources section to link all guide pages