### PR TITLE
Add video watermark support for screen recordings

### DIFF
--- a/Pointframe.Tests/Services/FFMpegVideoWriterTests.cs
+++ b/Pointframe.Tests/Services/FFMpegVideoWriterTests.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using Microsoft.Extensions.Logging.Abstractions;
+using Pointframe.Models;
 using Pointframe.Services;
 using Xunit;
 
@@ -183,6 +184,58 @@ public sealed class FFMpegVideoWriterTests
         FFMpegVideoWriter.BuildArguments(args, 128, 72, 20, "capture.mp4", "Studio \"Mic\"");
 
         Assert.Contains("audio=Studio \"Mic\"", args);
+    }
+
+    [Fact]
+    public void BuildArguments_WhenDrawtextFilterProvided_AddsVideoFilter()
+    {
+        var args = new List<string>();
+
+        FFMpegVideoWriter.BuildArguments(args, 128, 72, 20, "capture.mp4", null, "drawtext=fontfile='C\\:/Windows/Fonts/segoeui.ttf':text='stamp'");
+
+        var vfIndex = args.IndexOf("-vf");
+        Assert.True(vfIndex >= 0);
+        Assert.Contains("drawtext=", args[vfIndex + 1]);
+    }
+
+    [Fact]
+    public void BuildArguments_WhenDrawtextFilterMissing_DoesNotAddVideoFilter()
+    {
+        var args = new List<string>();
+
+        FFMpegVideoWriter.BuildArguments(args, 128, 72, 20, "capture.mp4", null, null);
+
+        Assert.DoesNotContain("-vf", args);
+    }
+
+    [Fact]
+    public void BuildDrawtextFilter_EscapesColonPercentAndQuote()
+    {
+        var settings = new ScreenshotWatermarkSettings
+        {
+            Enabled = true,
+            TextTemplate = WatermarkTextTemplate.DateTime,
+            Position = WatermarkPosition.BottomRight,
+            FontSize = 18,
+            ColorHex = "#FFFFFFFF",
+            BackgroundEnabled = true,
+            Opacity = 1.0,
+            Margin = 16,
+        };
+
+        var escaped = FFMpegVideoWriter.EscapeDrawtextValue("A:B % C ' D");
+        Assert.Equal("A\\:B \\% C \\' D", escaped);
+
+        var filter = FFMpegVideoWriter.BuildDrawtextFilter(
+            settings,
+            new DateTimeOffset(2026, 3, 18, 14, 5, 9, TimeSpan.FromHours(2)),
+            "Pointframe",
+            @"C:\Windows\Fonts\segoeui.ttf");
+
+        Assert.Contains("drawtext=", filter);
+        Assert.Contains("fontfile='C\\:/Windows/Fonts/segoeui.ttf'", filter);
+        Assert.Contains(":x=w-tw-16", filter);
+        Assert.Contains(":y=h-th-16", filter);
     }
 
     private static string InvokeResolveFfmpegPath()

--- a/Pointframe.Tests/Services/UserSettingsServiceTests.cs
+++ b/Pointframe.Tests/Services/UserSettingsServiceTests.cs
@@ -80,6 +80,38 @@ public sealed class UserSettingsServiceTests : IDisposable
         Assert.NotNull(sut.Current);
     }
 
+        [Fact]
+        public void Load_WhenVideoWatermarkMissing_DefaultsToScreenshotWatermark()
+        {
+                var settingsPath = Path.Combine(_tempDirectory, "settings.json");
+                Directory.CreateDirectory(_tempDirectory);
+                File.WriteAllText(
+                        settingsPath,
+                        """
+                        {
+                            "ScreenshotWatermark": {
+                                "Enabled": true,
+                                "TextTemplate": 1,
+                                "Position": 0,
+                                "FontSize": 24,
+                                "ColorHex": "#FFABCDEF",
+                                "BackgroundEnabled": false,
+                                "Opacity": 0.7,
+                                "Margin": 21,
+                                "ApplyToCopy": true,
+                                "ApplyToSave": false
+                            }
+                        }
+                        """);
+
+                var sut = new UserSettingsService(NullLogger<UserSettingsService>.Instance, settingsPath);
+
+                Assert.NotNull(sut.Current.VideoWatermark);
+                Assert.True(sut.Current.VideoWatermark.Enabled);
+                Assert.Equal(24, sut.Current.VideoWatermark.FontSize);
+                Assert.Equal("#FFABCDEF", sut.Current.VideoWatermark.ColorHex);
+        }
+
     [Fact]
     public void Save_PersistsProvidedSettingsAndUpdatesCurrent()
     {
@@ -101,6 +133,37 @@ public sealed class UserSettingsServiceTests : IDisposable
         Assert.True(persisted!.AutoSaveScreenshots);
         Assert.Equal(3, persisted.CaptureDelaySeconds);
         Assert.Equal(60, persisted.RecordingFps);
+    }
+
+    [Fact]
+    public void Update_ClonesVideoWatermarkSettings()
+    {
+        var settingsPath = Path.Combine(_tempDirectory, "settings.json");
+        var sut = new UserSettingsService(NullLogger<UserSettingsService>.Instance, settingsPath);
+        sut.Save(new UserSettings
+        {
+            VideoWatermark = new VideoWatermarkSettings
+            {
+                Enabled = true,
+                FontSize = 20,
+                Margin = 14,
+                TextTemplate = WatermarkTextTemplate.TimeOnly,
+                Position = WatermarkPosition.TopRight,
+            },
+        });
+
+        sut.Update(settings =>
+        {
+            Assert.NotNull(settings.VideoWatermark);
+            settings.VideoWatermark!.FontSize = 30;
+        });
+        Assert.NotNull(sut.Current.VideoWatermark);
+        Assert.Equal(30, sut.Current.VideoWatermark!.FontSize);
+
+        var persisted = JsonSerializer.Deserialize<UserSettings>(File.ReadAllText(settingsPath));
+        Assert.NotNull(persisted);
+        Assert.NotNull(persisted!.VideoWatermark);
+        Assert.Equal(30, persisted.VideoWatermark!.FontSize);
     }
 
     [Fact]

--- a/Pointframe.Tests/Services/VideoWriterFactoryTests.cs
+++ b/Pointframe.Tests/Services/VideoWriterFactoryTests.cs
@@ -1,5 +1,7 @@
 using System.IO;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Pointframe.Models;
 using Pointframe.Services;
 using Xunit;
 
@@ -8,8 +10,12 @@ namespace Pointframe.Tests.Services;
 [Collection("FfmpegPathOverride")]
 public sealed class VideoWriterFactoryTests
 {
-    private static VideoWriterFactory CreateSut() =>
-        new(NullLogger<FFMpegVideoWriter>.Instance);
+    private static VideoWriterFactory CreateSut()
+    {
+        var settings = new Mock<IUserSettingsService>();
+        settings.SetupGet(service => service.Current).Returns(new UserSettings());
+        return new(NullLogger<FFMpegVideoWriter>.Instance, settings.Object);
+    }
 
     private static IDisposable UseFfmpegPathOverride(string? path)
     {

--- a/Pointframe.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/Pointframe.Tests/ViewModels/SettingsViewModelTests.cs
@@ -817,7 +817,7 @@ public sealed class SettingsViewModelTests
     }
 
     [Fact]
-    public void Save_PreservesVideoWatermarkSettings()
+    public void Save_UpdatesVideoWatermarkFromCurrentWatermarkUiValues()
     {
         var current = new UserSettings
         {
@@ -850,12 +850,12 @@ public sealed class SettingsViewModelTests
         Assert.NotNull(saved);
         Assert.NotNull(saved!.VideoWatermark);
         Assert.True(saved.VideoWatermark!.Enabled);
-        Assert.Equal(WatermarkTextTemplate.TimeOnly, saved.VideoWatermark.TextTemplate);
-        Assert.Equal(WatermarkPosition.TopLeft, saved.VideoWatermark.Position);
-        Assert.Equal(22d, saved.VideoWatermark.FontSize);
-        Assert.Equal("#FF12AB34", saved.VideoWatermark.ColorHex);
-        Assert.False(saved.VideoWatermark.BackgroundEnabled);
-        Assert.Equal(0.8, saved.VideoWatermark.Opacity);
-        Assert.Equal(11d, saved.VideoWatermark.Margin);
+        Assert.Equal(WatermarkTextTemplate.DateOnly, saved.VideoWatermark.TextTemplate);
+        Assert.Equal(vm.WatermarkPosition, saved.VideoWatermark.Position);
+        Assert.Equal(vm.WatermarkFontSize, saved.VideoWatermark.FontSize);
+        Assert.Equal(current.ScreenshotWatermark.ColorHex, saved.VideoWatermark.ColorHex);
+        Assert.Equal(current.ScreenshotWatermark.BackgroundEnabled, saved.VideoWatermark.BackgroundEnabled);
+        Assert.Equal(current.ScreenshotWatermark.Opacity, saved.VideoWatermark.Opacity);
+        Assert.Equal(current.ScreenshotWatermark.Margin, saved.VideoWatermark.Margin);
     }
 }

--- a/Pointframe.Tests/ViewModels/SettingsViewModelTests.cs
+++ b/Pointframe.Tests/ViewModels/SettingsViewModelTests.cs
@@ -815,4 +815,47 @@ public sealed class SettingsViewModelTests
         Assert.Equal(defaults.ApplyToCopy, vm.WatermarkApplyToCopy);
         Assert.Equal(defaults.ApplyToSave, vm.WatermarkApplyToSave);
     }
+
+    [Fact]
+    public void Save_PreservesVideoWatermarkSettings()
+    {
+        var current = new UserSettings
+        {
+            VideoWatermark = new VideoWatermarkSettings
+            {
+                Enabled = true,
+                TextTemplate = WatermarkTextTemplate.TimeOnly,
+                Position = WatermarkPosition.TopLeft,
+                FontSize = 22d,
+                ColorHex = "#FF12AB34",
+                BackgroundEnabled = false,
+                Opacity = 0.8,
+                Margin = 11d,
+                ApplyToCopy = false,
+                ApplyToSave = false,
+            },
+        };
+
+        var mock = new Mock<IUserSettingsService>();
+        mock.SetupGet(s => s.Current).Returns(current);
+        UserSettings? saved = null;
+        mock.Setup(s => s.Save(It.IsAny<UserSettings>())).Callback<UserSettings>(s => saved = s);
+        var vm = new SettingsViewModel(mock.Object, Mock.Of<IThemeService>(), Mock.Of<IDialogService>(), CreateMicrophoneDeviceService());
+
+        vm.WatermarkEnabled = true;
+        vm.WatermarkTextTemplate = WatermarkTextTemplate.DateOnly;
+
+        vm.SaveCommand.Execute(null);
+
+        Assert.NotNull(saved);
+        Assert.NotNull(saved!.VideoWatermark);
+        Assert.True(saved.VideoWatermark!.Enabled);
+        Assert.Equal(WatermarkTextTemplate.TimeOnly, saved.VideoWatermark.TextTemplate);
+        Assert.Equal(WatermarkPosition.TopLeft, saved.VideoWatermark.Position);
+        Assert.Equal(22d, saved.VideoWatermark.FontSize);
+        Assert.Equal("#FF12AB34", saved.VideoWatermark.ColorHex);
+        Assert.False(saved.VideoWatermark.BackgroundEnabled);
+        Assert.Equal(0.8, saved.VideoWatermark.Opacity);
+        Assert.Equal(11d, saved.VideoWatermark.Margin);
+    }
 }

--- a/Pointframe/Models/ScreenshotWatermarkSettings.cs
+++ b/Pointframe/Models/ScreenshotWatermarkSettings.cs
@@ -1,15 +1,3 @@
 namespace Pointframe.Models;
 
-public sealed class ScreenshotWatermarkSettings
-{
-    public bool Enabled { get; set; }
-    public WatermarkTextTemplate TextTemplate { get; set; } = WatermarkTextTemplate.DateTime;
-    public WatermarkPosition Position { get; set; } = WatermarkPosition.BottomRight;
-    public double FontSize { get; set; } = 18;
-    public string ColorHex { get; set; } = "#FFFFFFFF";
-    public bool BackgroundEnabled { get; set; } = true;
-    public double Opacity { get; set; } = 1.0;
-    public double Margin { get; set; } = 16;
-    public bool ApplyToCopy { get; set; } = true;
-    public bool ApplyToSave { get; set; } = true;
-}
+public sealed class ScreenshotWatermarkSettings : WatermarkSettings;

--- a/Pointframe/Models/UserSettings.cs
+++ b/Pointframe/Models/UserSettings.cs
@@ -73,6 +73,8 @@ public sealed class UserSettings
 
     public ScreenshotWatermarkSettings ScreenshotWatermark { get; set; } = new();
 
+    public VideoWatermarkSettings? VideoWatermark { get; set; }
+
     /// <summary>
     /// Anonymous install identifier generated once on first run.
     /// Used for telemetry to count unique installs without tracking identity.

--- a/Pointframe/Models/VideoWatermarkSettings.cs
+++ b/Pointframe/Models/VideoWatermarkSettings.cs
@@ -1,0 +1,3 @@
+namespace Pointframe.Models;
+
+public sealed class VideoWatermarkSettings : WatermarkSettings;

--- a/Pointframe/Models/WatermarkSettings.cs
+++ b/Pointframe/Models/WatermarkSettings.cs
@@ -1,0 +1,15 @@
+namespace Pointframe.Models;
+
+public class WatermarkSettings
+{
+    public bool Enabled { get; set; }
+    public WatermarkTextTemplate TextTemplate { get; set; } = WatermarkTextTemplate.DateTime;
+    public WatermarkPosition Position { get; set; } = WatermarkPosition.BottomRight;
+    public double FontSize { get; set; } = 18;
+    public string ColorHex { get; set; } = "#FFFFFFFF";
+    public bool BackgroundEnabled { get; set; } = true;
+    public double Opacity { get; set; } = 1.0;
+    public double Margin { get; set; } = 16;
+    public bool ApplyToCopy { get; set; } = true;
+    public bool ApplyToSave { get; set; } = true;
+}

--- a/Pointframe/Services/Infrastructure/UserSettingsService.cs
+++ b/Pointframe/Services/Infrastructure/UserSettingsService.cs
@@ -41,6 +41,7 @@ public sealed class UserSettingsService : IUserSettingsService
             if (loaded is not null)
             {
                 loaded.ScreenshotWatermark ??= new Pointframe.Models.ScreenshotWatermarkSettings();
+                loaded.VideoWatermark ??= CloneVideoWatermark(loaded.ScreenshotWatermark);
                 _logger.LogInformation("Settings loaded from {Path}", _settingsPath);
                 return loaded;
             }
@@ -153,17 +154,36 @@ public sealed class UserSettingsService : IUserSettingsService
                 Color = p.Color,
                 StrokeThickness = p.StrokeThickness,
             })],
-            ScreenshotWatermark = CloneWatermark(settings.ScreenshotWatermark),
+            ScreenshotWatermark = CloneScreenshotWatermark(settings.ScreenshotWatermark),
+            VideoWatermark = CloneVideoWatermark(settings.VideoWatermark),
             InstallId = settings.InstallId,
             InstallCreatedUtc = settings.InstallCreatedUtc,
             FirstCaptureCompletedTracked = settings.FirstCaptureCompletedTracked,
             FirstRecordingCompletedTracked = settings.FirstRecordingCompletedTracked,
         };
 
-    private static Pointframe.Models.ScreenshotWatermarkSettings CloneWatermark(Pointframe.Models.ScreenshotWatermarkSettings? source)
+    private static Pointframe.Models.ScreenshotWatermarkSettings CloneScreenshotWatermark(Pointframe.Models.WatermarkSettings? source)
     {
         source ??= new Pointframe.Models.ScreenshotWatermarkSettings();
         return new Pointframe.Models.ScreenshotWatermarkSettings
+        {
+            Enabled = source.Enabled,
+            TextTemplate = source.TextTemplate,
+            Position = source.Position,
+            FontSize = source.FontSize,
+            ColorHex = source.ColorHex,
+            BackgroundEnabled = source.BackgroundEnabled,
+            Opacity = source.Opacity,
+            Margin = source.Margin,
+            ApplyToCopy = source.ApplyToCopy,
+            ApplyToSave = source.ApplyToSave,
+        };
+    }
+
+    private static Pointframe.Models.VideoWatermarkSettings CloneVideoWatermark(Pointframe.Models.WatermarkSettings? source)
+    {
+        source ??= new Pointframe.Models.VideoWatermarkSettings();
+        return new Pointframe.Models.VideoWatermarkSettings
         {
             Enabled = source.Enabled,
             TextTemplate = source.TextTemplate,

--- a/Pointframe/Services/Recording/FFMpegVideoWriter.cs
+++ b/Pointframe/Services/Recording/FFMpegVideoWriter.cs
@@ -1,10 +1,14 @@
+using System.Collections.Concurrent;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 
 namespace Pointframe.Services;
 
 public sealed class FFMpegVideoWriter : IVideoWriter
 {
+    private static readonly ConcurrentDictionary<string, bool> DrawtextSupportCache = new(StringComparer.OrdinalIgnoreCase);
+
     private readonly Process _ffmpeg;
     private readonly Stream _stdin;
     private readonly ILogger _logger;
@@ -16,11 +20,14 @@ public sealed class FFMpegVideoWriter : IVideoWriter
         int fps,
         string outputPath,
         ILogger logger,
-        string? microphoneDeviceName = null)
+        string? microphoneDeviceName = null,
+        WatermarkSettings? videoWatermark = null,
+        DateTimeOffset? watermarkTimestamp = null)
     {
         _logger = logger;
 
         var ffmpegPath = FfmpegResolver.ResolveRequired("Screen recording");
+        var drawtextFilter = TryBuildDrawtextFilter(ffmpegPath, videoWatermark, watermarkTimestamp ?? DateTimeOffset.Now, logger);
 
         var psi = new ProcessStartInfo
         {
@@ -30,7 +37,7 @@ public sealed class FFMpegVideoWriter : IVideoWriter
             RedirectStandardInput = true,
             RedirectStandardError = true,
         };
-        BuildArguments(psi.ArgumentList, width, height, fps, outputPath, microphoneDeviceName);
+        BuildArguments(psi.ArgumentList, width, height, fps, outputPath, microphoneDeviceName, drawtextFilter);
 
         _ffmpeg = new Process { StartInfo = psi };
 
@@ -51,6 +58,16 @@ public sealed class FFMpegVideoWriter : IVideoWriter
     public void WriteFrame(byte[] frameData) => _stdin.Write(frameData, 0, frameData.Length);
 
     internal static void BuildArguments(ICollection<string> args, int width, int height, int fps, string outputPath, string? microphoneDeviceName)
+        => BuildArguments(args, width, height, fps, outputPath, microphoneDeviceName, null);
+
+    internal static void BuildArguments(
+        ICollection<string> args,
+        int width,
+        int height,
+        int fps,
+        string outputPath,
+        string? microphoneDeviceName,
+        string? drawtextFilter)
     {
         var hasMicrophone = !string.IsNullOrWhiteSpace(microphoneDeviceName);
 
@@ -89,6 +106,12 @@ public sealed class FFMpegVideoWriter : IVideoWriter
             args.Add("1:a:0");
         }
 
+        if (!string.IsNullOrWhiteSpace(drawtextFilter))
+        {
+            args.Add("-vf");
+            args.Add(drawtextFilter);
+        }
+
         args.Add("-c:v");
         args.Add("libx264");
         args.Add("-preset");
@@ -111,6 +134,189 @@ public sealed class FFMpegVideoWriter : IVideoWriter
         }
 
         args.Add(outputPath);
+    }
+
+    internal static string BuildDrawtextFilter(
+        WatermarkSettings settings,
+        DateTimeOffset timestamp,
+        string appName,
+        string fontFilePath)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+        ArgumentNullException.ThrowIfNull(appName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fontFilePath);
+
+        var rawText = WatermarkTokenResolver.Resolve(settings.TextTemplate, timestamp)
+            .Replace("{app}", appName, StringComparison.OrdinalIgnoreCase);
+        var escapedText = EscapeDrawtextValue(rawText);
+        var escapedFontFile = EscapeDrawtextValue(fontFilePath.Replace('\\', '/'));
+        var fontColor = ToDrawtextColor(settings.ColorHex, settings.Opacity);
+        var fontSize = Math.Max(1, (int)Math.Round(settings.FontSize));
+        var margin = Math.Max(0, (int)Math.Round(settings.Margin));
+        var (x, y) = GetDrawtextCoordinates(settings.Position, margin);
+        var box = settings.BackgroundEnabled ? "1" : "0";
+
+        return $"drawtext=fontfile='{escapedFontFile}':text='{escapedText}':x={x}:y={y}:fontsize={fontSize}:fontcolor={fontColor}:box={box}:boxcolor=black@0.45:boxborderw=12";
+    }
+
+    internal static string EscapeDrawtextValue(string value)
+    {
+        return value
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace(":", "\\:", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("'", "\\'", StringComparison.Ordinal);
+    }
+
+    private static string? TryBuildDrawtextFilter(
+        string ffmpegPath,
+        WatermarkSettings? settings,
+        DateTimeOffset timestamp,
+        ILogger logger)
+    {
+        if (settings is not { Enabled: true })
+        {
+            return null;
+        }
+
+        var fontFilePath = ResolveFontFilePath();
+        if (fontFilePath is null)
+        {
+            logger.LogWarning("Video watermark requested, but no Windows font file was found. Recording will continue without watermark.");
+            return null;
+        }
+
+        if (!HasDrawtextFilter(ffmpegPath, logger))
+        {
+            logger.LogWarning("Video watermark requested, but ffmpeg drawtext filter is unavailable. Recording will continue without watermark.");
+            return null;
+        }
+
+        return BuildDrawtextFilter(settings, timestamp, "Pointframe", fontFilePath);
+    }
+
+    private static bool HasDrawtextFilter(string ffmpegPath, ILogger logger)
+    {
+        return DrawtextSupportCache.GetOrAdd(ffmpegPath, path => ProbeHasDrawtextFilter(path, logger));
+    }
+
+    private static bool ProbeHasDrawtextFilter(string ffmpegPath, ILogger logger)
+    {
+        try
+        {
+            using var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = ffmpegPath,
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                    RedirectStandardOutput = true,
+                    RedirectStandardError = true,
+                },
+            };
+
+            process.StartInfo.ArgumentList.Add("-hide_banner");
+            process.StartInfo.ArgumentList.Add("-filters");
+
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            var error = process.StandardError.ReadToEnd();
+            if (!process.WaitForExit(3000))
+            {
+                process.Kill();
+                logger.LogWarning("Timed out while probing ffmpeg filters; video watermark disabled for this recording.");
+                return false;
+            }
+
+            var combined = string.Concat(output, Environment.NewLine, error);
+            return combined.Contains("drawtext", StringComparison.OrdinalIgnoreCase);
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to probe ffmpeg drawtext support; video watermark disabled for this recording.");
+            return false;
+        }
+    }
+
+    private static string? ResolveFontFilePath()
+    {
+        var windows = Environment.GetFolderPath(Environment.SpecialFolder.Windows);
+        if (string.IsNullOrWhiteSpace(windows))
+        {
+            return null;
+        }
+
+        var candidates = new[]
+        {
+            Path.Combine(windows, "Fonts", "segoeui.ttf"),
+            Path.Combine(windows, "Fonts", "arial.ttf"),
+        };
+
+        return candidates.FirstOrDefault(File.Exists);
+    }
+
+    private static (string X, string Y) GetDrawtextCoordinates(WatermarkPosition position, int margin)
+    {
+        var marginText = margin.ToString(CultureInfo.InvariantCulture);
+        return position switch
+        {
+            WatermarkPosition.TopLeft => (marginText, marginText),
+            WatermarkPosition.TopRight => ($"w-tw-{marginText}", marginText),
+            WatermarkPosition.BottomLeft => (marginText, $"h-th-{marginText}"),
+            WatermarkPosition.BottomRight => ($"w-tw-{marginText}", $"h-th-{marginText}"),
+            WatermarkPosition.Center => ("(w-tw)/2", "(h-th)/2"),
+            _ => ($"w-tw-{marginText}", $"h-th-{marginText}"),
+        };
+    }
+
+    private static string ToDrawtextColor(string colorHex, double opacity)
+    {
+        var normalizedOpacity = Math.Clamp(opacity, 0d, 1d);
+        if (TryParseArgb(colorHex, out var a, out var r, out var g, out var b))
+        {
+            var alpha = Math.Clamp((a / 255d) * normalizedOpacity, 0d, 1d);
+            return $"#{r:X2}{g:X2}{b:X2}@{alpha.ToString("0.###", CultureInfo.InvariantCulture)}";
+        }
+
+        return $"white@{normalizedOpacity.ToString("0.###", CultureInfo.InvariantCulture)}";
+    }
+
+    private static bool TryParseArgb(string? colorHex, out byte a, out byte r, out byte g, out byte b)
+    {
+        a = 255;
+        r = 255;
+        g = 255;
+        b = 255;
+
+        if (string.IsNullOrWhiteSpace(colorHex))
+        {
+            return false;
+        }
+
+        var normalized = colorHex.Trim();
+        if (normalized.StartsWith("#", StringComparison.Ordinal))
+        {
+            normalized = normalized[1..];
+        }
+
+        if (normalized.Length == 8)
+        {
+            return byte.TryParse(normalized.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out a) &&
+                   byte.TryParse(normalized.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out r) &&
+                   byte.TryParse(normalized.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out g) &&
+                   byte.TryParse(normalized.AsSpan(6, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out b);
+        }
+
+        if (normalized.Length == 6)
+        {
+            a = 255;
+            return byte.TryParse(normalized.AsSpan(0, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out r) &&
+                   byte.TryParse(normalized.AsSpan(2, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out g) &&
+                   byte.TryParse(normalized.AsSpan(4, 2), NumberStyles.HexNumber, CultureInfo.InvariantCulture, out b);
+        }
+
+        return false;
     }
 
     public void Dispose()

--- a/Pointframe/Services/Recording/FFMpegVideoWriter.cs
+++ b/Pointframe/Services/Recording/FFMpegVideoWriter.cs
@@ -211,17 +211,14 @@ public sealed class FFMpegVideoWriter : IVideoWriter
                     FileName = ffmpegPath,
                     UseShellExecute = false,
                     CreateNoWindow = true,
-                    RedirectStandardOutput = true,
-                    RedirectStandardError = true,
                 },
             };
 
             process.StartInfo.ArgumentList.Add("-hide_banner");
-            process.StartInfo.ArgumentList.Add("-filters");
+            process.StartInfo.ArgumentList.Add("-h");
+            process.StartInfo.ArgumentList.Add("filter=drawtext");
 
             process.Start();
-            var output = process.StandardOutput.ReadToEnd();
-            var error = process.StandardError.ReadToEnd();
             if (!process.WaitForExit(3000))
             {
                 process.Kill();
@@ -229,8 +226,7 @@ public sealed class FFMpegVideoWriter : IVideoWriter
                 return false;
             }
 
-            var combined = string.Concat(output, Environment.NewLine, error);
-            return combined.Contains("drawtext", StringComparison.OrdinalIgnoreCase);
+            return process.ExitCode == 0;
         }
         catch (Exception ex)
         {

--- a/Pointframe/Services/Recording/VideoWriterFactory.cs
+++ b/Pointframe/Services/Recording/VideoWriterFactory.cs
@@ -3,14 +3,20 @@ namespace Pointframe.Services;
 public sealed class VideoWriterFactory : IVideoWriterFactory
 {
     private readonly ILogger<FFMpegVideoWriter> _ffmpegLogger;
+    private readonly IUserSettingsService _settingsService;
 
-    public VideoWriterFactory(ILogger<FFMpegVideoWriter> ffmpegLogger)
+    public VideoWriterFactory(ILogger<FFMpegVideoWriter> ffmpegLogger, IUserSettingsService settingsService)
     {
         _ffmpegLogger = ffmpegLogger;
+        _settingsService = settingsService;
     }
 
     public IVideoWriter Create(int width, int height, int fps, string outputPath, string? microphoneDeviceName)
     {
-        return new FFMpegVideoWriter(width, height, fps, outputPath, _ffmpegLogger, microphoneDeviceName);
+        var currentSettings = _settingsService.Current;
+        WatermarkSettings watermark = currentSettings.VideoWatermark is not null
+            ? currentSettings.VideoWatermark
+            : currentSettings.ScreenshotWatermark;
+        return new FFMpegVideoWriter(width, height, fps, outputPath, _ffmpegLogger, microphoneDeviceName, watermark, DateTimeOffset.Now);
     }
 }

--- a/Pointframe/ViewModels/SettingsViewModel.cs
+++ b/Pointframe/ViewModels/SettingsViewModel.cs
@@ -351,6 +351,9 @@ public partial class SettingsViewModel : ObservableObject
         var c = DefaultAnnotationColor;
         var clampedRecordingCursorHighlightSize = ClampRecordingCursorHighlightSize(RecordingCursorHighlightSize);
         var currentSettings = _settingsService.Current;
+        WatermarkSettings videoWatermark = currentSettings.VideoWatermark is not null
+            ? currentSettings.VideoWatermark
+            : currentSettings.ScreenshotWatermark;
         RecordingCursorHighlightSize = clampedRecordingCursorHighlightSize;
 
         _settingsService.Save(new UserSettings
@@ -379,6 +382,19 @@ public partial class SettingsViewModel : ObservableObject
                 BackgroundEnabled = _watermarkOther.BackgroundEnabled,
                 Opacity = _watermarkOther.Opacity,
                 Margin = _watermarkOther.Margin,
+            },
+            VideoWatermark = new VideoWatermarkSettings
+            {
+                Enabled = videoWatermark.Enabled,
+                TextTemplate = videoWatermark.TextTemplate,
+                Position = videoWatermark.Position,
+                FontSize = videoWatermark.FontSize,
+                ColorHex = videoWatermark.ColorHex,
+                BackgroundEnabled = videoWatermark.BackgroundEnabled,
+                Opacity = videoWatermark.Opacity,
+                Margin = videoWatermark.Margin,
+                ApplyToCopy = videoWatermark.ApplyToCopy,
+                ApplyToSave = videoWatermark.ApplyToSave,
             },
             DefaultAnnotationColor = $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}",
             DefaultStrokeThickness = DefaultStrokeThickness,

--- a/Pointframe/ViewModels/SettingsViewModel.cs
+++ b/Pointframe/ViewModels/SettingsViewModel.cs
@@ -351,9 +351,6 @@ public partial class SettingsViewModel : ObservableObject
         var c = DefaultAnnotationColor;
         var clampedRecordingCursorHighlightSize = ClampRecordingCursorHighlightSize(RecordingCursorHighlightSize);
         var currentSettings = _settingsService.Current;
-        WatermarkSettings videoWatermark = currentSettings.VideoWatermark is not null
-            ? currentSettings.VideoWatermark
-            : currentSettings.ScreenshotWatermark;
         RecordingCursorHighlightSize = clampedRecordingCursorHighlightSize;
 
         _settingsService.Save(new UserSettings
@@ -385,16 +382,16 @@ public partial class SettingsViewModel : ObservableObject
             },
             VideoWatermark = new VideoWatermarkSettings
             {
-                Enabled = videoWatermark.Enabled,
-                TextTemplate = videoWatermark.TextTemplate,
-                Position = videoWatermark.Position,
-                FontSize = videoWatermark.FontSize,
-                ColorHex = videoWatermark.ColorHex,
-                BackgroundEnabled = videoWatermark.BackgroundEnabled,
-                Opacity = videoWatermark.Opacity,
-                Margin = videoWatermark.Margin,
-                ApplyToCopy = videoWatermark.ApplyToCopy,
-                ApplyToSave = videoWatermark.ApplyToSave,
+                Enabled = WatermarkEnabled,
+                TextTemplate = WatermarkTextTemplate,
+                Position = WatermarkPosition,
+                FontSize = WatermarkFontSize,
+                ApplyToCopy = WatermarkApplyToCopy,
+                ApplyToSave = WatermarkApplyToSave,
+                ColorHex = _watermarkOther.ColorHex,
+                BackgroundEnabled = _watermarkOther.BackgroundEnabled,
+                Opacity = _watermarkOther.Opacity,
+                Margin = _watermarkOther.Margin,
             },
             DefaultAnnotationColor = $"#{c.A:X2}{c.R:X2}{c.G:X2}{c.B:X2}",
             DefaultStrokeThickness = DefaultStrokeThickness,

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "6.4",
+  "version": "6.5",
   "publicReleaseRefSpec": [
     "^refs/heads/master$",
     "^refs/tags/v\\d+\\.\\d+"


### PR DESCRIPTION
- Introduced WatermarkSettings base class; ScreenshotWatermarkSettings and new VideoWatermarkSettings now inherit from it
- UserSettings includes VideoWatermark; UserSettingsService ensures it is always present and properly cloned
- FFMpegVideoWriter overlays video watermark using ffmpeg drawtext filter, with runtime probing for filter and font
- VideoWriterFactory and SettingsViewModel updated to handle video watermark settings
- Added and updated tests for watermark persistence and ffmpeg argument generation
- Version bumped to 6.5