### PR TITLE
Add OCR support to CLI and MCP server

### DIFF
--- a/Pointframe.Cli/Application/CliApplication.cs
+++ b/Pointframe.Cli/Application/CliApplication.cs
@@ -19,7 +19,7 @@ internal sealed class CliApplication
     {
         try
         {
-            var directCaptureService = new DirectCaptureService(new DisplayCaptureEngine());
+            var directCaptureService = new DirectCaptureService(new DisplayCaptureEngine(), ocrEngineService: new WindowsOcrEngineService());
             return await new CliApplication(directCaptureService, standardOutput, standardError).RunAsync(args);
         }
         catch (Exception exception)
@@ -44,6 +44,7 @@ internal sealed class CliApplication
             {
                 "displays" => _directCaptureService.ListDisplays(),
                 "capture" => await _directCaptureService.CaptureMonitorAsync(command.MonitorName!, cancellationToken),
+                "ocr" => await _directCaptureService.CaptureMonitorTextAsync(command.MonitorName!, cancellationToken),
                 _ => throw new InvalidOperationException($"Unsupported CLI command '{command.Name}'."),
             };
 

--- a/Pointframe.Cli/Commands/CliCommandParser.cs
+++ b/Pointframe.Cli/Commands/CliCommandParser.cs
@@ -2,7 +2,7 @@ namespace Pointframe.Cli;
 
 internal static class CliCommandParser
 {
-    internal const string Usage = "Usage: pointframe-cli displays | capture --monitor <exact Windows device name> | ocr --monitor <exact Windows device name>";
+    internal const string Usage = "Usage: Pointframe.Cli.exe displays | capture --monitor <exact Windows device name> | ocr --monitor <exact Windows device name>";
 
     internal static bool TryParse(string[] args, out CliCommand command, out string? error)
     {

--- a/Pointframe.Cli/Commands/CliCommandParser.cs
+++ b/Pointframe.Cli/Commands/CliCommandParser.cs
@@ -2,7 +2,7 @@ namespace Pointframe.Cli;
 
 internal static class CliCommandParser
 {
-    internal const string Usage = "Usage: pointframe-cli displays | capture --monitor <exact Windows device name>";
+    internal const string Usage = "Usage: pointframe-cli displays | capture --monitor <exact Windows device name> | ocr --monitor <exact Windows device name>";
 
     internal static bool TryParse(string[] args, out CliCommand command, out string? error)
     {
@@ -25,10 +25,22 @@ internal static class CliCommandParser
             return true;
         }
 
+        if (args.Length == 3
+            && string.Equals(args[0], "ocr", StringComparison.OrdinalIgnoreCase)
+            && string.Equals(args[1], "--monitor", StringComparison.OrdinalIgnoreCase)
+            && !string.IsNullOrWhiteSpace(args[2]))
+        {
+            command = new CliCommand("ocr", args[2]);
+            error = null;
+            return true;
+        }
+
         command = default!;
         error = args.FirstOrDefault()?.Equals("capture", StringComparison.OrdinalIgnoreCase) == true
             ? "The capture command requires --monitor followed by an exact Windows device name."
-            : "Unknown or incomplete command.";
+            : args.FirstOrDefault()?.Equals("ocr", StringComparison.OrdinalIgnoreCase) == true
+                ? "The ocr command requires --monitor followed by an exact Windows device name."
+                : "Unknown or incomplete command.";
         return false;
     }
 }

--- a/Pointframe.Engine/Capture/Models/DirectCaptureModels.cs
+++ b/Pointframe.Engine/Capture/Models/DirectCaptureModels.cs
@@ -5,7 +5,8 @@ public sealed record DirectCaptureResponse(
     bool Success,
     DirectCaptureError? Error = null,
     IReadOnlyList<DisplayDescriptor>? Displays = null,
-    ArtifactDescriptor? Artifact = null);
+    ArtifactDescriptor? Artifact = null,
+    string? RecognizedText = null);
 
 public sealed record DirectCaptureError(string Code, string Message);
 

--- a/Pointframe.Engine/Capture/Services/DirectCaptureService.cs
+++ b/Pointframe.Engine/Capture/Services/DirectCaptureService.cs
@@ -18,17 +18,18 @@ public sealed class DirectCaptureService : IDirectCaptureService
 
     public DirectCaptureService(
         IDisplayCaptureEngine displayCaptureEngine,
+        IOcrEngineService ocrEngineService,
         string? screenshotsDirectory = null,
-        TimeProvider? timeProvider = null,
-        IOcrEngineService? ocrEngineService = null)
+        TimeProvider? timeProvider = null)
     {
+        ArgumentNullException.ThrowIfNull(ocrEngineService);
         _displayCaptureEngine = displayCaptureEngine;
         _screenshotsDirectory = screenshotsDirectory ?? Path.Combine(
             Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
             "Pointframe",
             "Screenshots");
         _timeProvider = timeProvider ?? TimeProvider.System;
-        _ocrEngineService = ocrEngineService ?? new WindowsOcrEngineService();
+        _ocrEngineService = ocrEngineService;
     }
 
     public string ListDisplays()

--- a/Pointframe.Engine/Capture/Services/DirectCaptureService.cs
+++ b/Pointframe.Engine/Capture/Services/DirectCaptureService.cs
@@ -12,13 +12,15 @@ public sealed class DirectCaptureService : IDirectCaptureService
         WriteIndented = true,
     };
     private readonly IDisplayCaptureEngine _displayCaptureEngine;
+    private readonly IOcrEngineService _ocrEngineService;
     private readonly string _screenshotsDirectory;
     private readonly TimeProvider _timeProvider;
 
     public DirectCaptureService(
         IDisplayCaptureEngine displayCaptureEngine,
         string? screenshotsDirectory = null,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        IOcrEngineService? ocrEngineService = null)
     {
         _displayCaptureEngine = displayCaptureEngine;
         _screenshotsDirectory = screenshotsDirectory ?? Path.Combine(
@@ -26,6 +28,7 @@ public sealed class DirectCaptureService : IDirectCaptureService
             "Pointframe",
             "Screenshots");
         _timeProvider = timeProvider ?? TimeProvider.System;
+        _ocrEngineService = ocrEngineService ?? new WindowsOcrEngineService();
     }
 
     public string ListDisplays()
@@ -36,6 +39,21 @@ public sealed class DirectCaptureService : IDirectCaptureService
 
     public async Task<string> CaptureMonitorAsync(string monitorName, CancellationToken cancellationToken = default)
     {
+        var (artifact, _) = await CaptureMonitorInternalAsync(monitorName, recognizeText: false, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Serialize(new DirectCaptureResponse(SchemaVersion, true, Artifact: artifact));
+    }
+
+    public async Task<string> CaptureMonitorTextAsync(string monitorName, CancellationToken cancellationToken = default)
+    {
+        var (artifact, recognizedText) = await CaptureMonitorInternalAsync(monitorName, recognizeText: true, cancellationToken).ConfigureAwait(false);
+        return JsonSerializer.Serialize(new DirectCaptureResponse(SchemaVersion, true, Artifact: artifact, RecognizedText: recognizedText));
+    }
+
+    private async Task<(ArtifactDescriptor Artifact, string? RecognizedText)> CaptureMonitorInternalAsync(
+        string monitorName,
+        bool recognizeText,
+        CancellationToken cancellationToken)
+    {
         ArgumentException.ThrowIfNullOrWhiteSpace(monitorName);
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -45,6 +63,10 @@ public sealed class DirectCaptureService : IDirectCaptureService
         var artifactId = Guid.NewGuid().ToString("N");
         var path = Path.Combine(_screenshotsDirectory, $"{createdUtc:yyyyMMdd-HHmmss}-{artifactId}.png");
         capturedMonitor.Bitmap.Save(path, ImageFormat.Png);
+
+        string? recognizedText = recognizeText
+            ? await _ocrEngineService.RecognizeAsync(capturedMonitor.Bitmap, cancellationToken).ConfigureAwait(false)
+            : null;
 
         string sha256;
         long byteLength;
@@ -69,7 +91,7 @@ public sealed class DirectCaptureService : IDirectCaptureService
             capturedMonitor.Display.BoundsPixels);
         await WriteMetadataSidecarAsync(metadata, cancellationToken);
         var artifact = new ArtifactDescriptor(SchemaVersion, artifactId, metadata);
-        return JsonSerializer.Serialize(new DirectCaptureResponse(SchemaVersion, true, Artifact: artifact));
+        return (artifact, recognizedText);
     }
 
     private static async Task WriteMetadataSidecarAsync(ImageArtifactMetadata metadata, CancellationToken cancellationToken)

--- a/Pointframe.Engine/Capture/Services/IDirectCaptureService.cs
+++ b/Pointframe.Engine/Capture/Services/IDirectCaptureService.cs
@@ -5,4 +5,6 @@ public interface IDirectCaptureService
     string ListDisplays();
 
     Task<string> CaptureMonitorAsync(string monitorName, CancellationToken cancellationToken = default);
+
+    Task<string> CaptureMonitorTextAsync(string monitorName, CancellationToken cancellationToken = default);
 }

--- a/Pointframe.Engine/Ocr/Services/IOcrEngineService.cs
+++ b/Pointframe.Engine/Ocr/Services/IOcrEngineService.cs
@@ -1,0 +1,8 @@
+using System.Drawing;
+
+namespace Pointframe.Engine;
+
+public interface IOcrEngineService
+{
+    Task<string?> RecognizeAsync(Bitmap bitmap, CancellationToken cancellationToken = default);
+}

--- a/Pointframe.Engine/Ocr/Services/WindowsOcrEngineService.cs
+++ b/Pointframe.Engine/Ocr/Services/WindowsOcrEngineService.cs
@@ -1,0 +1,55 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Runtime.InteropServices;
+using System.Runtime.InteropServices.WindowsRuntime;
+using Windows.Graphics.Imaging;
+using Windows.Media.Ocr;
+
+namespace Pointframe.Engine;
+
+public sealed class WindowsOcrEngineService : IOcrEngineService
+{
+    public async Task<string?> RecognizeAsync(Bitmap bitmap, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(bitmap);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var engine = OcrEngine.TryCreateFromUserProfileLanguages();
+        if (engine is null)
+        {
+            return null;
+        }
+
+        using var softwareBitmap = ConvertToSoftwareBitmap(bitmap);
+        var result = await engine.RecognizeAsync(softwareBitmap).AsTask(cancellationToken).ConfigureAwait(false);
+
+        if (result.Lines.Count == 0)
+        {
+            return null;
+        }
+
+        return string.Join(Environment.NewLine, result.Lines.Select(line => line.Text));
+    }
+
+    internal static SoftwareBitmap ConvertToSoftwareBitmap(Bitmap bitmap)
+    {
+        var bounds = new Rectangle(0, 0, bitmap.Width, bitmap.Height);
+        using var converted = bitmap.Clone(bounds, PixelFormat.Format32bppArgb);
+        var bitmapData = converted.LockBits(bounds, ImageLockMode.ReadOnly, PixelFormat.Format32bppArgb);
+        try
+        {
+            var byteCount = bitmapData.Stride * converted.Height;
+            var pixels = new byte[byteCount];
+            Marshal.Copy(bitmapData.Scan0, pixels, 0, byteCount);
+
+            // GDI+ Format32bppArgb stores bytes as B,G,R,A on little-endian Windows, matching Bgra8 directly.
+            var softwareBitmap = new SoftwareBitmap(BitmapPixelFormat.Bgra8, converted.Width, converted.Height, BitmapAlphaMode.Ignore);
+            softwareBitmap.CopyFromBuffer(pixels.AsBuffer());
+            return softwareBitmap;
+        }
+        finally
+        {
+            converted.UnlockBits(bitmapData);
+        }
+    }
+}

--- a/Pointframe.Mcp/Mappers/McpResponseMapper.cs
+++ b/Pointframe.Mcp/Mappers/McpResponseMapper.cs
@@ -50,7 +50,8 @@ internal static class McpResponseMapper
                         response.Artifact.Metadata.MonitorName,
                         response.Artifact.Metadata.DpiScaleX,
                         response.Artifact.Metadata.DpiScaleY,
-                        ToMcpBounds(response.Artifact.Metadata.CaptureBoundsPixels))));
+                        ToMcpBounds(response.Artifact.Metadata.CaptureBoundsPixels))),
+            response.RecognizedText);
     }
 
     private static McpRecordingResponse MapRecordingResponse(DirectRecordingResponse response)

--- a/Pointframe.Mcp/Models/McpToolResponses.cs
+++ b/Pointframe.Mcp/Models/McpToolResponses.cs
@@ -7,7 +7,8 @@ public sealed record McpCaptureResponse(
     bool Success,
     McpCaptureError? Error = null,
     IReadOnlyList<McpDisplayDescriptor>? Displays = null,
-    McpArtifactDescriptor? Artifact = null);
+    McpArtifactDescriptor? Artifact = null,
+    string? RecognizedText = null);
 
 public sealed record McpCaptureError(string Code, string Message);
 

--- a/Pointframe.Mcp/Program.cs
+++ b/Pointframe.Mcp/Program.cs
@@ -10,6 +10,7 @@ builder.Logging.ClearProviders();
 builder.Logging.SetMinimumLevel(LogLevel.Debug);
 builder.Logging.AddConsole(options => options.LogToStandardErrorThreshold = LogLevel.Trace);
 builder.Services.AddSingleton<IDisplayCaptureEngine, DisplayCaptureEngine>();
+builder.Services.AddSingleton<IOcrEngineService, WindowsOcrEngineService>();
 builder.Services.AddSingleton<IDirectCaptureService, DirectCaptureService>();
 builder.Services.AddSingleton<IDirectVideoWriterFactory, FfmpegDirectVideoWriterFactory>();
 builder.Services.AddSingleton<IDirectRecordingService, DirectRecordingService>();

--- a/Pointframe.Mcp/Resources/PointframeMcpResources.cs
+++ b/Pointframe.Mcp/Resources/PointframeMcpResources.cs
@@ -10,6 +10,6 @@ internal sealed class PointframeMcpResources
     [Description("Returns the available direct Pointframe MCP command identifiers.")]
     public static string GetCommands()
     {
-        return "[\"list_displays\",\"capture_monitor\",\"start_recording\",\"stop_recording\"]";
+        return "[\"list_displays\",\"capture_monitor\",\"read_text_from_monitor\",\"start_recording\",\"stop_recording\"]";
     }
 }

--- a/Pointframe.Mcp/Tools/PointframeMcpTools.cs
+++ b/Pointframe.Mcp/Tools/PointframeMcpTools.cs
@@ -34,6 +34,19 @@ internal sealed class PointframeMcpTools(IDirectCaptureService directCaptureServ
     }
 
     [McpServerTool(
+        Title = "Read text from monitor",
+        Destructive = false,
+        UseStructuredContent = true),
+     Description("Captures a Pointframe whole-monitor screenshot and recognizes on-screen text using Windows OCR. Returns both the saved PNG artifact and the recognized text; recognizedText is null when no text was found or no OCR language pack is installed.")]
+    public async Task<McpCaptureResponse> ReadTextFromMonitorAsync(
+        [Description("The exact Windows display device name, such as \\.\\DISPLAY1.")] string monitorName,
+        CancellationToken cancellationToken)
+    {
+        var json = await directCaptureService.CaptureMonitorTextAsync(monitorName, cancellationToken).ConfigureAwait(false);
+        return McpResponseMapper.DeserializeCaptureResponse(json);
+    }
+
+    [McpServerTool(
         Title = "Start recording",
         UseStructuredContent = true),
      Description("Starts direct, no-microphone MP4 recording for a monitor without launching the Pointframe desktop application. Redaction regions are required and use capture-local physical pixels; provide an empty array when none are needed.")]

--- a/Pointframe.Tests/Cli/CliApplicationTests.cs
+++ b/Pointframe.Tests/Cli/CliApplicationTests.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Text.Json;
+using Moq;
 using Pointframe.Cli;
 using Pointframe.Engine;
 using Xunit;
@@ -11,15 +12,18 @@ public sealed class CliApplicationTests
     [Fact]
     public async Task RunAsync_Displays_WritesDisplayDescriptorsJson()
     {
-        var directCaptureService = new FakeDirectCaptureService();
+        var directCaptureService = new Mock<IDirectCaptureService>();
+        directCaptureService
+            .Setup(service => service.ListDisplays())
+            .Returns("[{\"monitorName\":\"\\\\\\\\.\\\\DISPLAY1\"}]");
         var standardOutput = new StringWriter();
         var standardError = new StringWriter();
-        var application = new CliApplication(directCaptureService, standardOutput, standardError);
+        var application = new CliApplication(directCaptureService.Object, standardOutput, standardError);
 
         var exitCode = await application.RunAsync(["displays"]);
 
         Assert.Equal(0, exitCode);
-        Assert.Equal(1, directCaptureService.ListDisplaysCallCount);
+        directCaptureService.Verify(service => service.ListDisplays(), Times.Once);
         using var output = JsonDocument.Parse(standardOutput.ToString());
         Assert.Equal(@"\\.\DISPLAY1", output.RootElement[0].GetProperty("monitorName").GetString());
         Assert.Empty(standardError.ToString());
@@ -57,37 +61,60 @@ public sealed class CliApplicationTests
     }
 
     [Fact]
+    public void TryParse_Ocr_RequiresExactMonitorArgument()
+    {
+        var parsed = CliCommandParser.TryParse(["ocr", "--monitor", @"\\.\DISPLAY1"], out var command, out var error);
+
+        Assert.True(parsed);
+        Assert.Null(error);
+        Assert.Equal("ocr", command.Name);
+        Assert.Equal(@"\\.\DISPLAY1", command.MonitorName);
+    }
+
+    [Fact]
+    public void TryParse_OcrWithoutMonitor_ReturnsUsageError()
+    {
+        var parsed = CliCommandParser.TryParse(["ocr"], out _, out var error);
+
+        Assert.False(parsed);
+        Assert.Equal("The ocr command requires --monitor followed by an exact Windows device name.", error);
+    }
+
+    [Fact]
     public async Task RunAsync_Capture_WritesDirectArtifactJson()
     {
-        var directCaptureService = new FakeDirectCaptureService();
+        var directCaptureService = new Mock<IDirectCaptureService>();
+        directCaptureService
+            .Setup(service => service.CaptureMonitorAsync(@"\\.\DISPLAY1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("{\"artifact\":{\"metadata\":{\"artifactId\":\"artifact-1\"}}}");
         var standardOutput = new StringWriter();
         var standardError = new StringWriter();
-        var application = new CliApplication(directCaptureService, standardOutput, standardError);
+        var application = new CliApplication(directCaptureService.Object, standardOutput, standardError);
 
         var exitCode = await application.RunAsync(["capture", "--monitor", @"\\.\DISPLAY1"]);
 
         Assert.Equal(0, exitCode);
-        Assert.Equal(@"\\.\DISPLAY1", directCaptureService.CapturedMonitorName);
+        directCaptureService.Verify(service => service.CaptureMonitorAsync(@"\\.\DISPLAY1", It.IsAny<CancellationToken>()), Times.Once);
         Assert.Contains("artifact-1", standardOutput.ToString(), StringComparison.Ordinal);
         Assert.Empty(standardError.ToString());
     }
 
-    private sealed class FakeDirectCaptureService : IDirectCaptureService
+    [Fact]
+    public async Task RunAsync_Ocr_WritesRecognizedTextJson()
     {
-        public string? CapturedMonitorName { get; private set; }
+        var directCaptureService = new Mock<IDirectCaptureService>();
+        directCaptureService
+            .Setup(service => service.CaptureMonitorTextAsync(@"\\.\DISPLAY1", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("{\"artifact\":{\"metadata\":{\"artifactId\":\"artifact-1\"}},\"recognizedText\":\"Hello world\"}");
+        var standardOutput = new StringWriter();
+        var standardError = new StringWriter();
+        var application = new CliApplication(directCaptureService.Object, standardOutput, standardError);
 
-        public int ListDisplaysCallCount { get; private set; }
+        var exitCode = await application.RunAsync(["ocr", "--monitor", @"\\.\DISPLAY1"]);
 
-        public string ListDisplays()
-        {
-            ListDisplaysCallCount++;
-            return "[{\"monitorName\":\"\\\\\\\\.\\\\DISPLAY1\"}]";
-        }
-
-        public Task<string> CaptureMonitorAsync(string monitorName, CancellationToken cancellationToken = default)
-        {
-            CapturedMonitorName = monitorName;
-            return Task.FromResult("{\"artifact\":{\"metadata\":{\"artifactId\":\"artifact-1\"}}}");
-        }
+        Assert.Equal(0, exitCode);
+        directCaptureService.Verify(service => service.CaptureMonitorTextAsync(@"\\.\DISPLAY1", It.IsAny<CancellationToken>()), Times.Once);
+        Assert.Contains("Hello world", standardOutput.ToString(), StringComparison.Ordinal);
+        Assert.Empty(standardError.ToString());
     }
 }

--- a/Pointframe.Tests/Engine/RawFrameRecordingPipelineTests.cs
+++ b/Pointframe.Tests/Engine/RawFrameRecordingPipelineTests.cs
@@ -15,7 +15,7 @@ public sealed class RawFrameRecordingPipelineTests
             new RawFrameRecordingOptions(new PixelBounds(0, 0, 1, 1), 10, () => ReadOnlyMemory<PixelBounds>.Empty),
             capture);
 
-        Assert.True(capture.Captured.Wait(TimeSpan.FromSeconds(1)));
+        Assert.True(capture.Captured.Wait(TimeSpan.FromSeconds(10)));
         Assert.True(writer.FirstFrameWritten.Wait(TimeSpan.FromSeconds(10)));
         var statistics = pipeline.Stop(TimeSpan.FromMilliseconds(250));
 

--- a/Pointframe.Tests/Engine/WindowsOcrEngineServiceTests.cs
+++ b/Pointframe.Tests/Engine/WindowsOcrEngineServiceTests.cs
@@ -1,8 +1,10 @@
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Reflection;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Pointframe.Engine;
 using Windows.Graphics.Imaging;
+using Windows.Storage.Streams;
 using Xunit;
 
 namespace Pointframe.Tests.Engine;
@@ -27,6 +29,15 @@ public sealed class WindowsOcrEngineServiceTests
         Assert.Equal(2, softwareBitmap.PixelHeight);
         Assert.Equal(BitmapPixelFormat.Bgra8, softwareBitmap.BitmapPixelFormat);
         Assert.Equal(BitmapAlphaMode.Ignore, softwareBitmap.BitmapAlphaMode);
+
+        var buffer = new Windows.Storage.Streams.Buffer((uint)(softwareBitmap.PixelWidth * softwareBitmap.PixelHeight * 4));
+        softwareBitmap.CopyToBuffer(buffer);
+        var pixelBytes = buffer.ToArray();
+
+        AssertPixelBgra(pixelBytes, pixelIndex: 0, Color.Black);
+        AssertPixelBgra(pixelBytes, pixelIndex: 1, Color.Red);
+        AssertPixelBgra(pixelBytes, pixelIndex: 2, Color.Green);
+        AssertPixelBgra(pixelBytes, pixelIndex: 3, Color.Blue);
     }
 
     [Fact]
@@ -35,5 +46,14 @@ public sealed class WindowsOcrEngineServiceTests
         var sut = new WindowsOcrEngineService();
 
         await Assert.ThrowsAsync<ArgumentNullException>(() => sut.RecognizeAsync(null!));
+    }
+
+    private static void AssertPixelBgra(byte[] pixels, int pixelIndex, Color expected)
+    {
+        var offset = pixelIndex * 4;
+        Assert.Equal(expected.B, pixels[offset]);
+        Assert.Equal(expected.G, pixels[offset + 1]);
+        Assert.Equal(expected.R, pixels[offset + 2]);
+        Assert.Equal(expected.A, pixels[offset + 3]);
     }
 }

--- a/Pointframe.Tests/Engine/WindowsOcrEngineServiceTests.cs
+++ b/Pointframe.Tests/Engine/WindowsOcrEngineServiceTests.cs
@@ -1,0 +1,39 @@
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.Reflection;
+using Pointframe.Engine;
+using Windows.Graphics.Imaging;
+using Xunit;
+
+namespace Pointframe.Tests.Engine;
+
+public sealed class WindowsOcrEngineServiceTests
+{
+    [Fact]
+    public void ConvertToSoftwareBitmap_CopiesDimensionsAndPixels()
+    {
+        using var bitmap = new Bitmap(2, 2, PixelFormat.Format32bppArgb);
+        bitmap.SetPixel(0, 0, Color.Black);
+        bitmap.SetPixel(1, 0, Color.Red);
+        bitmap.SetPixel(0, 1, Color.Green);
+        bitmap.SetPixel(1, 1, Color.Blue);
+
+        var method = typeof(WindowsOcrEngineService).GetMethod("ConvertToSoftwareBitmap", BindingFlags.NonPublic | BindingFlags.Static);
+        Assert.NotNull(method);
+
+        using var softwareBitmap = (SoftwareBitmap)method.Invoke(null, [bitmap])!;
+
+        Assert.Equal(2, softwareBitmap.PixelWidth);
+        Assert.Equal(2, softwareBitmap.PixelHeight);
+        Assert.Equal(BitmapPixelFormat.Bgra8, softwareBitmap.BitmapPixelFormat);
+        Assert.Equal(BitmapAlphaMode.Ignore, softwareBitmap.BitmapAlphaMode);
+    }
+
+    [Fact]
+    public async Task RecognizeAsync_NullBitmap_Throws()
+    {
+        var sut = new WindowsOcrEngineService();
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => sut.RecognizeAsync(null!));
+    }
+}

--- a/Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs
+++ b/Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs
@@ -20,7 +20,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
             1.5,
             1.25,
             new Pointframe.Engine.PixelBounds(-20, 10, 2, 3));
-        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), new Mock<IOcrEngineService>().Object, _screenshotsDirectory);
 
         var json = await sut.CaptureMonitorAsync(display.MonitorName);
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
@@ -51,7 +51,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
             1d,
             1d,
             new Pointframe.Engine.PixelBounds(0, 0, 100, 200));
-        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), new Mock<IOcrEngineService>().Object, _screenshotsDirectory);
 
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(sut.ListDisplays());
 
@@ -74,7 +74,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
         ocrEngineService
             .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("Hello world");
-        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), ocrEngineService.Object, _screenshotsDirectory);
 
         var json = await sut.CaptureMonitorTextAsync(display.MonitorName);
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
@@ -99,7 +99,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
         ocrEngineService
             .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((string?)null);
-        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), ocrEngineService.Object, _screenshotsDirectory);
 
         var json = await sut.CaptureMonitorTextAsync(display.MonitorName);
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
@@ -121,7 +121,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
         ocrEngineService
             .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync("unused");
-        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), ocrEngineService.Object, _screenshotsDirectory);
 
         var json = await sut.CaptureMonitorAsync(display.MonitorName);
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);

--- a/Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs
+++ b/Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs
@@ -2,6 +2,7 @@ using System.Drawing;
 using System.IO;
 using System.Security.Cryptography;
 using System.Text.Json;
+using Moq;
 using Pointframe.Engine;
 using Xunit;
 
@@ -19,7 +20,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
             1.5,
             1.25,
             new Pointframe.Engine.PixelBounds(-20, 10, 2, 3));
-        var sut = new DirectCaptureService(new FakeDisplayCaptureEngine(display), _screenshotsDirectory);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory);
 
         var json = await sut.CaptureMonitorAsync(display.MonitorName);
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
@@ -50,7 +51,7 @@ public sealed class DirectCaptureServiceTests : IDisposable
             1d,
             1d,
             new Pointframe.Engine.PixelBounds(0, 0, 100, 200));
-        var sut = new DirectCaptureService(new FakeDisplayCaptureEngine(display), _screenshotsDirectory);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory);
 
         var response = JsonSerializer.Deserialize<DirectCaptureResponse>(sut.ListDisplays());
 
@@ -61,6 +62,75 @@ public sealed class DirectCaptureServiceTests : IDisposable
         Assert.Equal(new Pointframe.Engine.PixelBounds(0, 0, 100, 200), returnedDisplay.BoundsPixels);
     }
 
+    [Fact]
+    public async Task CaptureMonitorTextAsync_WritesArtifactAndReturnsRecognizedText()
+    {
+        var display = new Pointframe.Engine.DisplayDescriptor(
+            @"\\.\DISPLAY1",
+            1.5,
+            1.25,
+            new Pointframe.Engine.PixelBounds(-20, 10, 2, 3));
+        var ocrEngineService = new Mock<IOcrEngineService>();
+        ocrEngineService
+            .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("Hello world");
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+
+        var json = await sut.CaptureMonitorTextAsync(display.MonitorName);
+        var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
+
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.Equal("Hello world", response.RecognizedText);
+        var artifact = Assert.IsType<ArtifactDescriptor>(response.Artifact);
+        Assert.True(File.Exists(artifact.Metadata.Path));
+        ocrEngineService.Verify(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CaptureMonitorTextAsync_WhenOcrFindsNoText_ReturnsNullRecognizedText()
+    {
+        var display = new Pointframe.Engine.DisplayDescriptor(
+            @"\\.\DISPLAY1",
+            1d,
+            1d,
+            new Pointframe.Engine.PixelBounds(0, 0, 100, 200));
+        var ocrEngineService = new Mock<IOcrEngineService>();
+        ocrEngineService
+            .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+
+        var json = await sut.CaptureMonitorTextAsync(display.MonitorName);
+        var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
+
+        Assert.NotNull(response);
+        Assert.True(response.Success);
+        Assert.Null(response.RecognizedText);
+    }
+
+    [Fact]
+    public async Task CaptureMonitorAsync_DoesNotInvokeOcr()
+    {
+        var display = new Pointframe.Engine.DisplayDescriptor(
+            @"\\.\DISPLAY1",
+            1d,
+            1d,
+            new Pointframe.Engine.PixelBounds(0, 0, 100, 200));
+        var ocrEngineService = new Mock<IOcrEngineService>();
+        ocrEngineService
+            .Setup(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync("unused");
+        var sut = new DirectCaptureService(CreateDisplayCaptureEngine(display), _screenshotsDirectory, ocrEngineService: ocrEngineService.Object);
+
+        var json = await sut.CaptureMonitorAsync(display.MonitorName);
+        var response = JsonSerializer.Deserialize<DirectCaptureResponse>(json);
+
+        Assert.NotNull(response);
+        Assert.Null(response.RecognizedText);
+        ocrEngineService.Verify(service => service.RecognizeAsync(It.IsAny<Bitmap>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     public void Dispose()
     {
         if (Directory.Exists(_screenshotsDirectory))
@@ -69,26 +139,18 @@ public sealed class DirectCaptureServiceTests : IDisposable
         }
     }
 
-    private sealed class FakeDisplayCaptureEngine(Pointframe.Engine.DisplayDescriptor display) : IDisplayCaptureEngine
+    private static IDisplayCaptureEngine CreateDisplayCaptureEngine(Pointframe.Engine.DisplayDescriptor display)
     {
-        public IReadOnlyList<Pointframe.Engine.DisplayDescriptor> GetDisplays()
-        {
-            return [display];
-        }
-
-        public Bitmap Capture(Pointframe.Engine.PixelBounds boundsPixels)
-        {
-            return new Bitmap(boundsPixels.Width, boundsPixels.Height);
-        }
-
-        public CapturedMonitor CaptureMonitor(string monitorName)
-        {
-            if (!string.Equals(display.MonitorName, monitorName, StringComparison.OrdinalIgnoreCase))
-            {
-                throw new ArgumentException("Unknown monitor.", nameof(monitorName));
-            }
-
-            return new CapturedMonitor(display, Capture(display.BoundsPixels));
-        }
+        var displayCaptureEngine = new Mock<IDisplayCaptureEngine>();
+        displayCaptureEngine
+            .Setup(engine => engine.GetDisplays())
+            .Returns([display]);
+        displayCaptureEngine
+            .Setup(engine => engine.Capture(It.IsAny<Pointframe.Engine.PixelBounds>()))
+            .Returns((Pointframe.Engine.PixelBounds bounds) => new Bitmap(bounds.Width, bounds.Height));
+        displayCaptureEngine
+            .Setup(engine => engine.CaptureMonitor(It.Is<string>(monitorName => string.Equals(monitorName, display.MonitorName, StringComparison.OrdinalIgnoreCase))))
+            .Returns(new CapturedMonitor(display, new Bitmap(display.BoundsPixels.Width, display.BoundsPixels.Height)));
+        return displayCaptureEngine.Object;
     }
 }

--- a/README.md
+++ b/README.md
@@ -76,12 +76,16 @@ desktop from a Windows service (session 0).
 ```powershell
 .\Pointframe.Cli.exe displays
 .\Pointframe.Cli.exe capture --monitor '\\.\DISPLAY1'
+.\Pointframe.Cli.exe ocr --monitor '\\.\DISPLAY1'
 ```
 
 Use the exact `monitorName` emitted by `displays`. A successful command writes JSON
 to standard output and exits with code `0`; invalid arguments exit with code `2`, and
 capture failures exit with code `1`. Screenshots and their metadata sidecars are saved
-under `%LOCALAPPDATA%\Pointframe\Screenshots`.
+under `%LOCALAPPDATA%\Pointframe\Screenshots`. `ocr` captures the monitor the same way
+`capture` does, then runs Windows OCR against the captured image and adds a
+`recognizedText` field to the JSON output (`null` when no text is found or no OCR
+language pack is installed).
 
 ## Pointframe MCP Server
 
@@ -93,15 +97,16 @@ The standalone host requires an interactive Windows desktop session. It is a loc
 
 The server exposes:
 
-- `list_displays` — return monitor identifiers, physical pixel bounds, and DPI scales.
-- `capture_monitor` — capture a named monitor and return a PNG artifact plus metadata.
-- `start_recording` — start a whole-monitor MP4 recording. Recording requires an explicit `redactionRegionsCaptureLocalPixels` array, even when it is empty.
-- `stop_recording` — stop the active recording and return the finalized MP4 artifact, metadata, and event sidecar references.
+- 🖥️ `list_displays` — return monitor identifiers, physical pixel bounds, and DPI scales.
+- 📸 `capture_monitor` — capture a named monitor and return a PNG artifact plus metadata.
+- 🔤 `read_text_from_monitor` — capture a named monitor and run OCR against it, returning the PNG artifact plus recognized text (`null` when no text is found or no OCR language pack is installed).
+- 🎥 `start_recording` — start a whole-monitor MP4 recording. Recording requires an explicit `redactionRegionsCaptureLocalPixels` array, even when it is empty.
+- ⏹️ `stop_recording` — stop the active recording and return the finalized MP4 artifact, metadata, and event sidecar references.
 
 The normal workflow is:
 
 1. Call `list_displays` and select a returned `monitorName`.
-2. Call `capture_monitor` with that exact monitor name, or call `start_recording`.
+2. Call `capture_monitor` with that exact monitor name, call `read_text_from_monitor` to also extract on-screen text, or call `start_recording`.
 3. For recording, pass redaction rectangles in capture-local physical pixels. Use `[]` when no redaction is required.
 4. Call `stop_recording` to finalize the MP4 and retrieve its metadata.
 
@@ -135,6 +140,9 @@ rather than a text-only description of the Windows desktop:
 - **Bug report capture:** call `list_displays`, select the affected monitor, then
   call `capture_monitor` to produce a PNG and metadata sidecar that can be attached
   to a report.
+- **Reading on-screen text:** call `read_text_from_monitor` to extract error dialogs,
+  logs, or terminal output as plain text alongside the screenshot, without a separate
+  OCR step.
 - **Privacy-safe support recording:** call `start_recording` with capture-local
   rectangles covering credentials, tokens, customer data, or other sensitive areas,
   then call `stop_recording` when the reproduction is complete. Redaction is applied
@@ -232,11 +240,11 @@ dotnet build Pointframe.Mcp/Pointframe.Mcp.csproj
   -ExecutablePath ".\Pointframe.Mcp\bin\Debug\net10.0-windows10.0.18362.0\Pointframe.Mcp.exe"
 ```
 
-The smoke test verifies the MCP initialize handshake and confirms that all four
+The smoke test verifies the MCP initialize handshake and confirms that all five
 tools are advertised. To test an actual capture, configure the executable in VS
-Code, call `list_displays`, then call `capture_monitor` with one of the returned
-monitor names. A successful capture should have a matching `.metadata.json`
-sidecar whose SHA-256 and byte length agree with the image.
+Code, call `list_displays`, then call `capture_monitor` (or `read_text_from_monitor`)
+with one of the returned monitor names. A successful capture should have a matching
+`.metadata.json` sidecar whose SHA-256 and byte length agree with the image.
 
 Recording currently captures a whole monitor without microphone audio. Redaction regions are capture-local physical pixels and are applied before ffmpeg receives the frame. The process must run in the logged-in interactive Windows session; Windows services running in session 0 cannot capture the user desktop.
 

--- a/docs/knowledge-base/knowledge-base.md
+++ b/docs/knowledge-base/knowledge-base.md
@@ -58,6 +58,7 @@ pwsh .claude/skills/knowledge-base/knowledge-base.ps1 -Check   # check only
   - [Recording width and height are even](#recording-width-and-height-are-even)
   - [DIPs and physical pixels are converted explicitly per monitor](#dips-and-physical-pixels-are-converted-explicitly-per-monitor)
   - [Everything emitted next to the exe must be in the installer file list](#everything-emitted-next-to-the-exe-must-be-in-the-installer-file-list)
+  - [The MCP command list resource must name every registered tool](#the-mcp-command-list-resource-must-name-every-registered-tool)
 - [How-tos](#how-tos)
   - [Add an annotation tool](#add-an-annotation-tool)
   - [Add a user setting](#add-a-user-setting)
@@ -260,9 +261,10 @@ Text and Callout edit in a live `TextBox`; `LostFocus` converts it to a `TextBlo
 
 **Capabilities.**
 
-- The CLI accepts `displays` or `capture --monitor <exact Windows device name>`. Invalid or incomplete commands print usage and return exit code 2; execution failures return exit code 1.
+- The CLI accepts `displays`, `capture --monitor <exact Windows device name>`, or `ocr --monitor <exact Windows device name>`. Invalid or incomplete commands print usage and return exit code 2; execution failures return exit code 1.
 - The MCP resource `pointframe://commands` lists the supported command identifiers.
-- MCP tools list displays, capture a named monitor to a PNG artifact, start a no-microphone MP4 recording, and stop that recording with finalized artifact and sidecar metadata.
+- MCP tools list displays, capture a named monitor to a PNG artifact, read text from a named monitor (capture plus OCR) via `read_text_from_monitor`, start a no-microphone MP4 recording, and stop that recording with finalized artifact and sidecar metadata.
+- OCR (`ocr` CLI command / `read_text_from_monitor` MCP tool) captures the monitor like `capture` does, then runs `Windows.Media.Ocr.OcrEngine` against the captured bitmap via `IOcrEngineService`/`WindowsOcrEngineService`. The response always includes the PNG artifact; `recognizedText` is `null` when no text is found or no OCR language pack is installed for the user's profile languages. `DirectCaptureService.CaptureMonitorInternalAsync` is the shared helper behind both `CaptureMonitorAsync` and `CaptureMonitorTextAsync` so save/hash/metadata-sidecar logic isn't duplicated.
 - Recording requires an explicit redaction-region array. Regions are capture-local physical pixels and are applied before frames reach ffmpeg.
 
 **Packaging and configuration.**
@@ -278,10 +280,11 @@ CI publishes the CLI and MCP executables and runs `packaging/test-mcp-stdio.ps1`
 - Capture and recording must run in the logged-in interactive desktop session; Windows services in session 0 cannot capture the user desktop.
 - Monitor names passed to CLI/MCP commands are exact Windows device names, such as `\\.\DISPLAY1`.
 - Artifact paths and metadata are produced through the shared direct services under `%LOCALAPPDATA%\Pointframe`; recording also emits an event sidecar without bitmap data, OCR text, clipboard contents, or prompts.
+- `Pointframe.Engine` targets `net10.0-windows10.0.18362.0` and can call WinRT APIs (`Windows.Media.Ocr`, `Windows.Graphics.Imaging`) directly without a WPF dependency. `WindowsOcrEngineService` converts from GDI+ `System.Drawing.Bitmap` (what the capture pipeline produces) straight to `SoftwareBitmap`, unlike the main WPF app's `WindowsOcrService`, which converts from WPF's `BitmapSource`. Do not introduce a WPF dependency into `Pointframe.Engine` to reuse the WPF OCR service; keep the two implementations separate.
 
-**Tests.** `Pointframe.Tests/Cli/CliApplicationTests.cs`, `Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs`, `Pointframe.Tests/Mcp/DirectRecordingMcpServiceTests.cs`, and `Pointframe.Tests/Engine/DirectRecordingServiceTests.cs`. Protocol smoke coverage is in `packaging/test-mcp-stdio.ps1`.
+**Tests.** `Pointframe.Tests/Cli/CliApplicationTests.cs`, `Pointframe.Tests/Mcp/DirectCaptureServiceTests.cs`, `Pointframe.Tests/Mcp/DirectRecordingMcpServiceTests.cs`, `Pointframe.Tests/Engine/DirectRecordingServiceTests.cs`, and `Pointframe.Tests/Engine/WindowsOcrEngineServiceTests.cs`. Protocol smoke coverage is in `packaging/test-mcp-stdio.ps1`.
 
-**Files.** `Pointframe.Cli/Program.cs`, `Pointframe.Cli/Application/CliApplication.cs`, `Pointframe.Cli/Commands/CliCommandParser.cs`, `Pointframe.Cli/Commands/CliCommand.cs`, `Pointframe.Mcp/Program.cs`, `Pointframe.Mcp/Tools/PointframeMcpTools.cs`, `Pointframe.Mcp/Resources/PointframeMcpResources.cs`, `Pointframe.Mcp/Services/DirectRecordingMcpService.cs`, `Pointframe.Mcp/Mappers/McpResponseMapper.cs`, `Pointframe.Mcp/Models/DirectRecordingResponse.cs`, `Pointframe.Mcp/Models/McpToolResponses.cs`, `Pointframe.Engine/Capture/Services/DirectCaptureService.cs`, `Pointframe.Engine/Capture/Services/DisplayCaptureEngine.cs`, `Pointframe.Engine/Capture/Models/DirectCaptureModels.cs`, `Pointframe.Engine/Recording/Services/DirectRecordingService.cs`, `Pointframe.Engine/Recording/Services/RawFrameRecordingPipeline.cs`, `Pointframe.Engine/Recording/Services/FfmpegDirectVideoWriter.cs`, `Pointframe.Engine/Recording/Models/DirectRecordingModels.cs`, `Pointframe/Services/Recording/ArtifactMetadataService.cs`, `packaging/build-cli-package.ps1`, `packaging/build-mcp-package.ps1`, `packaging/test-mcp-stdio.ps1`, `.github/workflows/ci.yml`, `.github/workflows/cd.yml`.
+**Files.** `Pointframe.Cli/Program.cs`, `Pointframe.Cli/Application/CliApplication.cs`, `Pointframe.Cli/Commands/CliCommandParser.cs`, `Pointframe.Cli/Commands/CliCommand.cs`, `Pointframe.Mcp/Program.cs`, `Pointframe.Mcp/Tools/PointframeMcpTools.cs`, `Pointframe.Mcp/Resources/PointframeMcpResources.cs`, `Pointframe.Mcp/Services/DirectRecordingMcpService.cs`, `Pointframe.Mcp/Mappers/McpResponseMapper.cs`, `Pointframe.Mcp/Models/DirectRecordingResponse.cs`, `Pointframe.Mcp/Models/McpToolResponses.cs`, `Pointframe.Engine/Capture/Services/DirectCaptureService.cs`, `Pointframe.Engine/Capture/Services/DisplayCaptureEngine.cs`, `Pointframe.Engine/Capture/Models/DirectCaptureModels.cs`, `Pointframe.Engine/Ocr/Services/IOcrEngineService.cs`, `Pointframe.Engine/Ocr/Services/WindowsOcrEngineService.cs`, `Pointframe.Engine/Recording/Services/DirectRecordingService.cs`, `Pointframe.Engine/Recording/Services/RawFrameRecordingPipeline.cs`, `Pointframe.Engine/Recording/Services/FfmpegDirectVideoWriter.cs`, `Pointframe.Engine/Recording/Models/DirectRecordingModels.cs`, `Pointframe/Services/Recording/ArtifactMetadataService.cs`, `packaging/build-cli-package.ps1`, `packaging/build-mcp-package.ps1`, `packaging/test-mcp-stdio.ps1`, `.github/workflows/ci.yml`, `.github/workflows/cd.yml`.
 
 **Files.** `Pointframe/Services/Recording/ScreenRecordingService.cs`, `Pointframe/Services/Recording/IScreenRecordingService.cs`, `Pointframe/Services/Recording/IRecordingRedactionSession.cs`, `Pointframe/Services/Recording/RecordingRedactionSession.cs`, `Pointframe/Services/Recording/IRecordingEventTrack.cs`, `Pointframe/Services/Recording/RecordingEventTrack.cs`, `Pointframe/Services/Recording/VideoWriterFactory.cs`, `Pointframe/Services/Recording/FFMpegVideoWriter.cs`, `Pointframe/Services/Recording/FfmpegResolver.cs`, `Pointframe/Models/RecordingSessionGeometry.cs`, `Pointframe/Views/RecordingOverlayWindow.xaml.cs`, `Pointframe/Views/OverlayWindow.Recording.cs`, `Pointframe/Views/OverlayWindow.RecordingHud.cs`, `Pointframe/Views/OverlayWindow.RecordingAnnotation.cs`, `Pointframe/Views/CountdownWindow.xaml.cs`, `Pointframe/ViewModels/RecordingHudViewModel.cs`, `Pointframe/Services/Recording/RecordingHudCoordinator.cs`, `Pointframe/Services/Recording/RecordingAnnotationSurfaceCoordinator.cs`, `Pointframe/Services/Recording/RecordingMousePassthroughCoordinator.cs`, `Pointframe/Services/Recording/RecordingOverlayNativeInterop.cs`, `Pointframe/Services/Recording/RecordingCursorEffectsService.cs`, `Pointframe/Services/Recording/RecordingMicrophoneSession.cs`, `Pointframe/Services/Infrastructure/MicrophoneDeviceService.cs`, `Pointframe/Services/Recording/GifExportService.cs`, `Pointframe/Services/Recording/VideoTrimService.cs`, `Pointframe/ViewModels/TrimViewModel.cs`, `Pointframe/Services/Recording/WatermarkTokenResolver.cs`, `Pointframe/Services/Messaging/RecordingCompletedMessage.cs`, `Pointframe/Services/Messaging/TrimRecordingRequestedMessage.cs`.
 
@@ -625,6 +628,18 @@ dip         = physical_px / scale
 **Lessons.**
 
 - Lesson: Turning off single-file native bundling silently breaks the installer, not the dev build
+
+### The MCP command list resource must name every registered tool
+
+**Rule.** `PointframeMcpResources.GetCommands()` returns a hardcoded JSON array of command identifiers. Every `[McpServerTool]` method added to `PointframeMcpTools` needs its snake_case tool name (for example `read_text_from_monitor`) added to that array in the same change.
+
+**Why.** MCP clients that call the `pointframe://commands` resource before `tools/list` use it as a cheap capability check. The array is not generated from the tool attributes, so nothing keeps it in sync automatically; a new tool method compiles and works over MCP even if the resource still lists only the older commands, silently telling callers the new capability does not exist.
+
+**Enforced by.** `packaging/test-mcp-stdio.ps1`'s `$expectedTools` list checks `tools/list`, not the `pointframe://commands` resource, so it does not catch a stale resource. There is no automated check for this file; review `PointframeMcpResources.cs` whenever `PointframeMcpTools.cs` gains or removes a tool.
+
+**Symptoms when violated.** A client that gates on `pointframe://commands` never offers the new tool to the user or agent, even though calling it directly still succeeds.
+
+**Files.** `Pointframe.Mcp/Resources/PointframeMcpResources.cs`, `Pointframe.Mcp/Tools/PointframeMcpTools.cs`, `packaging/test-mcp-stdio.ps1`. See [Standalone CLI and MCP automation](#standalone-cli-and-mcp-automation).
 
 ## How-tos
 

--- a/packaging/test-mcp-stdio.ps1
+++ b/packaging/test-mcp-stdio.ps1
@@ -101,7 +101,7 @@ try
     }
 
     $toolNames = @($toolsResponse.result.tools | ForEach-Object { $_.name })
-    $expectedTools = @("list_displays", "capture_monitor", "start_recording", "stop_recording")
+    $expectedTools = @("list_displays", "capture_monitor", "read_text_from_monitor", "start_recording", "stop_recording")
     foreach ($expectedTool in $expectedTools)
     {
         if ($toolNames -notcontains $expectedTool)


### PR DESCRIPTION
Added OCR commands to CLI (`ocr --monitor <name>`) and MCP server (`read_text_from_monitor` tool) to capture monitor screenshots and extract on-screen text using Windows OCR. Introduced `IOcrEngineService` and `WindowsOcrEngineService` for text recognition from bitmaps, injected into `DirectCaptureService`. Refactored capture logic to avoid duplication. Updated command parsing, help text, error handling, and MCP command list resource. Added and updated unit tests for OCR integration. Updated README and knowledge base with OCR usage and requirements.